### PR TITLE
Add a function to get the safe address of a supplier

### DIFF
--- a/contracts/BridgeUtils.sol
+++ b/contracts/BridgeUtils.sol
@@ -35,6 +35,11 @@ contract BridgeUtils is Initializable, Safe, Ownable {
     return suppliers[supplierAddr].registered;
   }
 
+  function safeForSupplier(address supplierAddr) public view returns (address) {
+    require(isRegistered(supplierAddr), "supplier is not registered");
+    return suppliers[supplierAddr].safe;
+  }
+
   function setup(
     address _revenuePool,
     address _prepaidCardManager,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "bugs": {
     "url": "https://github.com/cardstack/card-protocol-xdai/issues"
   },
+  "engines": {
+    "node": ">=14.0"
+  },
   "homepage": "https://github.com/cardstack/card-protocol-xdai#readme",
   "devDependencies": {
     "@chainlink/contracts": "^0.1.7",

--- a/test/BridgeUtils-test.js
+++ b/test/BridgeUtils-test.js
@@ -152,6 +152,7 @@ contract("BridgeUtils", async (accounts) => {
     expect(supplier["safe"]).to.equal(wallet);
     expect(supplier["brandName"]).to.equal("Zion");
     expect(supplier["brandProfileUrl"]).to.equal("https://www.zion.com");
+    expect(await bridgeUtils.safeForSupplier(supplierAddr)).to.equal(wallet);
   });
 
   it("rejects an update to a non-supplier address", async () => {


### PR DESCRIPTION
This allows querying the address of a supplier's safe without knowing about
the supplier struct

The reason this is necessary is that I am using an interface and a mock in the tokenbridge contracts to interact with the bridgeutils contract, and as far as I can tell, there's no way for an interface to define a function that returns a struct and also use that struct in the concrete implementation in solidity 0.4