### PR TITLE
Fixes #CS-873 don't allow clients to supply contract signatures

### DIFF
--- a/test/utils/helper.js
+++ b/test/utils/helper.js
@@ -124,17 +124,12 @@ async function payMerchant(
     prepaidCard
   );
 
-  let signatures = await prepaidCardManager.appendPrepaidCardAdminSignature(
-    customerAddress,
-    signature
-  );
-
   return await prepaidCardManager.payForMerchant(
     prepaidCard.address,
     issuingToken.address,
     merchantSafe,
     amount,
-    signatures,
+    signature,
     { from: relayer }
   );
 }
@@ -328,10 +323,12 @@ exports.transferOwner = async function (
   newOwner,
   relayer
 ) {
-  let xferData = [prepaidCard.address, oldOwner, newOwner];
   let packData = packExecutionData({
     to: prepaidCard.address,
-    data: await prepaidCardManager.getSellCardData(oldOwner, newOwner),
+    data: await prepaidCardManager.getSellCardData(
+      prepaidCard.address,
+      newOwner
+    ),
   });
   let safeTxArr = Object.keys(packData).map((key) => packData[key]);
   let signature = await signSafeTransaction(
@@ -341,14 +338,9 @@ exports.transferOwner = async function (
     prepaidCard
   );
 
-  await prepaidCardManager.sellCard(
-    ...xferData,
-    await prepaidCardManager.appendPrepaidCardAdminSignature(
-      oldOwner,
-      signature
-    ),
-    { from: relayer }
-  );
+  await prepaidCardManager.sellCard(prepaidCard.address, newOwner, signature, {
+    from: relayer,
+  });
 };
 
 exports.registerMerchant = async function (


### PR DESCRIPTION
This logic makes the contract signatures an internal feature of the PrepaidCardManager contract. Now the contract will only solicit the EOA safe owner's signature, then the contract will perform the various checks to make sure the action should be permitted, and only after all the checks pass will the contract then add it's own signature to the gnosis safe transaction.

also as part of this I noticed that in the split card function we were not checking to make sure that the a prepaid card cannot be split after it's been transferred to a customer, so that logic and test has been added