### PR TITLE
Making prepaid cards more flexible

### DIFF
--- a/contracts/PrepaidCardManager.sol
+++ b/contracts/PrepaidCardManager.sol
@@ -235,8 +235,8 @@ contract PrepaidCardManager is Initializable, Versionable, PayableToken, Safe {
         cardDetails[prepaidCard].issueToken,
         getSendData(prepaidCard, spendAmount, rateLock, action, data),
         addContractSignature(prepaidCard, ownerSignature),
-        gasToken,
-        prepaidCard
+        gasToken, // TODO we should look up the gas token to use for the requested action
+        prepaidCard // TODO we should look up the gas receiver to use for the requested action
       );
   }
 

--- a/contracts/RevenuePool.sol
+++ b/contracts/RevenuePool.sol
@@ -379,9 +379,10 @@ contract RevenuePool is Versionable, Initializable, MerchantManager, Exchange {
     uint256 spendAmount,
     uint256 requestedRate
   ) internal view returns (bool) {
-    if (tokenAmount == 0 && spendAmount == 0) {
-      return true;
-    }
+    // TODO add this as soon as we handle merchant claims via prepaid card
+    // if (tokenAmount == 0 && spendAmount == 0) {
+    //   return true;
+    // }
     uint256 expectedTokenAmount =
       convertFromSpendWithRate(token, spendAmount, requestedRate);
     require(

--- a/test/utils/helper.js
+++ b/test/utils/helper.js
@@ -98,59 +98,11 @@ async function signAndSendSafeTransaction(
     safeTx,
   };
 }
-async function payMerchant(
-  prepaidCardManager,
-  prepaidCard,
-  issuingToken,
-  gasToken,
-  relayer,
-  customerAddress,
-  merchantSafe,
-  spendAmount,
-  usdRate
-) {
-  if (usdRate == null) {
-    usdRate = 100000000; // 1 DAI = 1 USD
-  }
-  let data = await prepaidCardManager.getSendData(
-    prepaidCard.address,
-    spendAmount,
-    usdRate,
-    "payMerchant",
-    AbiCoder.encodeParameters(["address"], [merchantSafe])
-  );
-
-  let signature = await signSafeTransaction(
-    issuingToken.address,
-    0,
-    data,
-    0,
-    0,
-    0,
-    0,
-    gasToken.address,
-    prepaidCard.address,
-    await prepaidCard.nonce(),
-    customerAddress,
-    prepaidCard
-  );
-
-  return await prepaidCardManager.send(
-    prepaidCard.address,
-    spendAmount,
-    usdRate,
-    "payMerchant",
-    AbiCoder.encodeParameters(["address"], [merchantSafe]),
-    signature,
-    { from: relayer }
-  );
-}
 
 exports.toTokenUnit = toTokenUnit;
 exports.encodeCreateCardsData = encodeCreateCardsData;
 exports.packExecutionData = packExecutionData;
 exports.signAndSendSafeTransaction = signAndSendSafeTransaction;
-exports.payMerchant = payMerchant;
 
 exports.shouldBeSameBalance = async function (token, address, amount) {
   await token.balanceOf(address).should.eventually.be.a.bignumber.equal(amount);
@@ -410,6 +362,54 @@ exports.registerMerchant = async function (
     usdRate,
     "registerMerchant",
     AbiCoder.encodeParameters(["string"], [infoDID]),
+    signature,
+    { from: relayer }
+  );
+};
+
+exports.payMerchant = async function (
+  prepaidCardManager,
+  prepaidCard,
+  issuingToken,
+  gasToken,
+  relayer,
+  customerAddress,
+  merchantSafe,
+  spendAmount,
+  usdRate
+) {
+  if (usdRate == null) {
+    usdRate = 100000000; // 1 DAI = 1 USD
+  }
+  let data = await prepaidCardManager.getSendData(
+    prepaidCard.address,
+    spendAmount,
+    usdRate,
+    "payMerchant",
+    AbiCoder.encodeParameters(["address"], [merchantSafe])
+  );
+
+  let signature = await signSafeTransaction(
+    issuingToken.address,
+    0,
+    data,
+    0,
+    0,
+    0,
+    0,
+    gasToken.address,
+    prepaidCard.address,
+    await prepaidCard.nonce(),
+    customerAddress,
+    prepaidCard
+  );
+
+  return await prepaidCardManager.send(
+    prepaidCard.address,
+    spendAmount,
+    usdRate,
+    "payMerchant",
+    AbiCoder.encodeParameters(["address"], [merchantSafe]),
     signature,
     { from: relayer }
   );


### PR DESCRIPTION
This allows our prepaid cards to be more flexible. In this change we are acknowledging the fact that prepaid cards are used to do more things than just pay merchants. This allows us to add additional capabilities to prepaid cards without having to worry about updating the relay server, as new capabilities are accompanied by their own arbitrary encoded data shapes.