### PR TITLE
fixup reward pool complete coverage

### DIFF
--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -127,9 +127,6 @@ contract RewardPool is Initializable, Versionable, Ownable {
     bytes32[] memory _proof;
 
     (meta, _proof) = splitIntoBytes32(proof, 2);
-    if (meta.length != 2) {
-      return 0;
-    }
 
     uint256 paymentCycleNumber = uint256(meta[0]);
     uint256 cumulativeAmount = uint256(meta[1]);


### PR DESCRIPTION
this [commit](https://github.com/cardstack/card-protocol-xdai/pull/67/commits/a0e98005929d6c4f124d3c1244464d66019ac35f) was overidden by the upstream changes in previous pr. 