### PR TITLE
Add token field to reward claim

### DIFF
--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -21,6 +21,7 @@ contract RewardPool is Initializable, Versionable, Ownable {
     address rewardProgramID,
     address rewardee,
     address rewardSafe,
+    address token
     uint256 amount
   );
   event MerkleRootSubmission(bytes32 payeeRoot, uint256 numPaymentCycles);
@@ -140,7 +141,7 @@ contract RewardPool is Initializable, Versionable, Ownable {
       .sub(amount);
     IERC677(payableToken).transfer(msg.sender, amount);
 
-    emit RewardeeClaim(rewardProgramID, rewardSafeOwner, msg.sender, amount);
+    emit RewardeeClaim(rewardProgramID, rewardSafeOwner, msg.sender, payableToken, amount);
     return true;
   }
 

--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -21,7 +21,7 @@ contract RewardPool is Initializable, Versionable, Ownable {
     address rewardProgramID,
     address rewardee,
     address rewardSafe,
-    address token
+    address token,
     uint256 amount
   );
   event MerkleRootSubmission(bytes32 payeeRoot, uint256 numPaymentCycles);


### PR DESCRIPTION
reward claim event is missing a token field. this helps us understand what token is being claimed. It is unimportant now because card.cpxd is the only reward token but it will be important later when we add facility for other tokens.

subgraph `RewardeeClaim` doesn't track this. Following a deploy of cardpay protocol to sokol we need to:
- update contract in sdk
- update abi of reward pool in sdk
- add token field into `RewardeeClaim` entity

**BREAKING CHANGE due to change of event structure**
