### PR TITLE
Parallelise tests with mocha (yarn test:parallel)

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,6 @@
+require: ['hardhat/register', 'test/setup']
+ui: 'bdd'
+timeout: 10000
+parallel: true
+recursive: true
+extension: ['js', 'cjs', 'mjs', 'ts']

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ To run all the tests execute:
 yarn test
 ```
 
+Or to run in parallel execute:
+
+```sh
+yarn test:parallel
+```
+
 The tests include a gas report which provides the min, max, and avg gas consumed for all the public functions in the contract based on the gas consumed while running tests, as well as, the gas required to deploy the contracts.
 
 To generate the test coverage report execute:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "./node_modules/.bin/hardhat compile && ./node_modules/.bin/hardhat typechain",
     "build:clean": "rm -rf typechain && ./node_modules/.bin/hardhat clean && yarn build",
     "test": "yarn lint && yarn test:sol",
+    "test:parallel": "yarn lint && npx mocha",
     "test:sol": "./node_modules/.bin/hardhat test",
     "test:coverage": "./node_modules/.bin/hardhat coverage",
     "test:size": "{ ./node_modules/.bin/hardhat size-contracts | tee /dev/fd/3 | grep -q 'exceed the size limit for mainnet deployment' && exit 1; } 3>&1 || echo 'All contracts within size limit'",


### PR DESCRIPTION
This adds a new command to run tests in parallel using mocha.

Mocha executes one thread *per test file* so the runtime is tied to how
many cores you have and how split up the test files are.

On a 32 core machine this cuts the runtime down from 3 minutes to under
1 minute. This could be reduced further by splitting up the test files but
this is beyond the scope of this commit.

More information can be found here:
https://developer.ibm.com/articles/parallel-tests-mocha-v8/