### PR TITLE
Fix import casing error

### DIFF
--- a/contracts/commerce-protocol/Contracts.sol
+++ b/contracts/commerce-protocol/Contracts.sol
@@ -5,7 +5,7 @@ pragma solidity 0.6.8;
 // This contract exists solely to pull in the contracts from the CardPay-Contracts package,
 // so that they are built by hardhat and included in the artifacts directory
 
-import "CardPay-Contracts/contracts/BaseERC20.sol";
+import "CardPay-Contracts/contracts/BaseErc20.sol";
 import "CardPay-Contracts/contracts/ExchangeMock.sol";
 import "CardPay-Contracts/contracts/Inventory.sol";
 import "CardPay-Contracts/contracts/LevelRegistrar.sol";


### PR DESCRIPTION
When I run `yarn build:clean` I get an error

```
Error HH409: Trying to import CardPay-Contracts/contracts/BaseERC20.sol from contracts/commerce-protocol/Contracts.sol, but it has an incorrect casing.
```

This change fixes the build