### PR TITLE
Make prepaid card test less-stateful

### DIFF
--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -978,25 +978,15 @@ contract("PrepaidCardManager", (accounts) => {
 
     it("a prepaid card cannot be split after it is transferred", async () => {
       await daicpxdToken.mint(depot.address, toTokenUnit(3));
-      let {
-        prepaidCards: [prepaidCard],
-      } = await createPrepaidCards(
-        depot,
+      let prepaidCard = await createPrepaidCardAndTransfer(
         prepaidCardManager,
-        daicpxdToken,
-        issuer,
         relayer,
-        [toTokenUnit(2)]
-      );
-
-      await transferOwner(
-        prepaidCardManager,
-        prepaidCard,
+        depot,
         issuer,
-        customer,
-        relayer
+        daicpxdToken,
+        toTokenUnit(2),
+        customer
       );
-
       let amounts = [1, 1].map((amount) => toTokenUnit(amount).toString());
       await splitPrepaidCard(
         prepaidCardManager,

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -1499,22 +1499,14 @@ contract("PrepaidCardManager", (accounts) => {
     });
 
     it("can sign with address lexigraphically before prepaid card manager contract address", async () => {
-      let {
-        prepaidCards: [prepaidCardA],
-      } = await createPrepaidCards(
-        depot,
+      let prepaidCardA = await createPrepaidCardAndTransfer(
         prepaidCardManager,
-        daicpxdToken,
-        issuer,
         relayer,
-        [toTokenUnit(1)]
-      );
-      await transferOwner(
-        prepaidCardManager,
-        prepaidCardA,
+        depot,
         issuer,
-        customerA,
-        relayer
+        daicpxdToken,
+        toTokenUnit(1),
+        customerA
       );
 
       let startingPrepaidCardDaicpxdBalance = await getBalance(
@@ -1546,22 +1538,14 @@ contract("PrepaidCardManager", (accounts) => {
     });
 
     it("can sign with address lexigraphically after prepaid card manager contract address", async () => {
-      let {
-        prepaidCards: [prepaidCardB],
-      } = await createPrepaidCards(
-        depot,
+      let prepaidCardB = await createPrepaidCardAndTransfer(
         prepaidCardManager,
-        daicpxdToken,
-        issuer,
         relayer,
-        [toTokenUnit(1)]
-      );
-      await transferOwner(
-        prepaidCardManager,
-        prepaidCardB,
+        depot,
         issuer,
-        customerB,
-        relayer
+        daicpxdToken,
+        toTokenUnit(5),
+        customerB
       );
 
       let startingPrepaidCardDaicpxdBalance = await getBalance(

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -243,11 +243,10 @@ contract("PrepaidCardManager", (accounts) => {
     });
   });
 
-  describe.only("create prepaid card", () => {
+  describe("create prepaid card", () => {
     let walletAmount;
 
     before(async () => {
-      walletAmount = toTokenUnit(1000);
       await prepaidCardManager.setup(
         tokenManager.address,
         supplierManager.address,

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -241,11 +241,27 @@ contract("PrepaidCardManager", (accounts) => {
     });
   });
 
-  describe("create prepaid card", () => {
+  describe.only("create prepaid card", () => {
     let walletAmount;
 
-    before(() => {
+    before(async () => {
       walletAmount = toTokenUnit(1000);
+      await prepaidCardManager.setup(
+        tokenManager.address,
+        supplierManager.address,
+        exchange.address,
+        gnosisSafeMasterCopy.address,
+        proxyFactory.address,
+        actionDispatcher.address,
+        gasFeeReceiver,
+        0,
+        MINIMUM_AMOUNT,
+        MAXIMUM_AMOUNT,
+        [contractSigner],
+        versionManager.address
+      );
+      await prepaidCardManager.addGasPolicy("transfer", false);
+      await prepaidCardManager.addGasPolicy("split", false);
     });
 
     beforeEach(async () => {

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -67,7 +67,8 @@ contract("PrepaidCardManager", (accounts) => {
     contractSigner,
     relayer,
     depot,
-    prepaidCards = [];
+    prepaidCards = [],
+    walletAmount;
 
   before(async () => {
     owner = accounts[0];
@@ -78,6 +79,7 @@ contract("PrepaidCardManager", (accounts) => {
     gasFeeReceiver = accounts[5];
     merchantFeeReceiver = accounts[6];
     contractSigner = accounts[7];
+    walletAmount = toTokenUnit(1000);
 
     versionManager = await setupVersionManager(owner);
     proxyFactory = await ProxyFactory.new();

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -945,6 +945,25 @@ contract("PrepaidCardManager", (accounts) => {
         amounts
       ));
     });
+
+    afterEach(async () => {
+      // burn all token in depot wallet
+      let balance = await daicpxdToken.balanceOf(depot.address);
+      let data = daicpxdToken.contract.methods.burn(balance).encodeABI();
+
+      let safeTxData = {
+        to: daicpxdToken.address,
+        data,
+      };
+
+      await signAndSendSafeTransaction(safeTxData, issuer, depot, relayer);
+
+      // burn all token in relayer wallet
+      await daicpxdToken.burn(await daicpxdToken.balanceOf(relayer), {
+        from: relayer,
+      });
+    });
+
     it("can split a card (from 1 prepaid card with 2 tokens to 2 cards with 1 token each)", async () => {
       let amounts = [1, 1].map((amount) => toTokenUnit(amount).toString());
       let safeTx = await splitPrepaidCard(

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -244,8 +244,6 @@ contract("PrepaidCardManager", (accounts) => {
   });
 
   describe("create prepaid card", () => {
-    let walletAmount;
-
     before(async () => {
       await prepaidCardManager.setup(
         tokenManager.address,

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -33,6 +33,7 @@ const {
   setupVersionManager,
   createPrepaidCardAndTransfer,
   registerMerchant,
+  burnDepotTokens,
 } = require("./utils/helper");
 
 const { expect, TOKEN_DETAIL_DATA, toBN } = require("./setup");
@@ -271,17 +272,7 @@ contract("PrepaidCardManager", (accounts) => {
     });
 
     afterEach(async () => {
-      // burn all token in depot wallet
-      let balance = await daicpxdToken.balanceOf(depot.address);
-      let data = daicpxdToken.contract.methods.burn(balance).encodeABI();
-
-      let safeTxData = {
-        to: daicpxdToken.address,
-        data,
-      };
-
-      await signAndSendSafeTransaction(safeTxData, issuer, depot, relayer);
-
+      await burnDepotTokens(depot, daicpxdToken, issuer, relayer);
       // burn all token in relayer wallet
       await daicpxdToken.burn(await daicpxdToken.balanceOf(relayer), {
         from: relayer,
@@ -596,17 +587,7 @@ contract("PrepaidCardManager", (accounts) => {
     });
 
     afterEach(async () => {
-      // burn all token in depot wallet
-      let balance = await daicpxdToken.balanceOf(depot.address);
-      let data = daicpxdToken.contract.methods.burn(balance).encodeABI();
-
-      let safeTxData = {
-        to: daicpxdToken.address,
-        data,
-      };
-
-      await signAndSendSafeTransaction(safeTxData, issuer, depot, relayer);
-
+      await burnDepotTokens(depot, daicpxdToken, issuer, relayer);
       // burn all token in relayer wallet
       await daicpxdToken.burn(await daicpxdToken.balanceOf(relayer), {
         from: relayer,
@@ -949,17 +930,7 @@ contract("PrepaidCardManager", (accounts) => {
     });
 
     afterEach(async () => {
-      // burn all token in depot wallet
-      let balance = await daicpxdToken.balanceOf(depot.address);
-      let data = daicpxdToken.contract.methods.burn(balance).encodeABI();
-
-      let safeTxData = {
-        to: daicpxdToken.address,
-        data,
-      };
-
-      await signAndSendSafeTransaction(safeTxData, issuer, depot, relayer);
-
+      await burnDepotTokens(depot, daicpxdToken, issuer, relayer);
       // burn all token in relayer wallet
       await daicpxdToken.burn(await daicpxdToken.balanceOf(relayer), {
         from: relayer,
@@ -1206,17 +1177,7 @@ contract("PrepaidCardManager", (accounts) => {
     });
 
     afterEach(async () => {
-      // burn all token in depot wallet
-      let balance = await daicpxdToken.balanceOf(depot.address);
-      let data = daicpxdToken.contract.methods.burn(balance).encodeABI();
-
-      let safeTxData = {
-        to: daicpxdToken.address,
-        data,
-      };
-
-      await signAndSendSafeTransaction(safeTxData, issuer, depot, relayer);
-
+      await burnDepotTokens(depot, daicpxdToken, issuer, relayer);
       // burn all token in relayer wallet
       await daicpxdToken.burn(await daicpxdToken.balanceOf(relayer), {
         from: relayer,
@@ -1367,7 +1328,7 @@ contract("PrepaidCardManager", (accounts) => {
     });
   });
 
-  describe.only("use prepaid card for payment", () => {
+  describe("use prepaid card for payment", () => {
     let prepaidCard;
 
     before(async () => {
@@ -1385,16 +1346,6 @@ contract("PrepaidCardManager", (accounts) => {
         [contractSigner],
         versionManager.address
       );
-      // await revenuePool.setup(
-      //   exchange.address,
-      //   merchantManager.address,
-      //   actionDispatcher.address,
-      //   prepaidCardManager.address,
-      //   merchantFeeReceiver,
-      //   0,
-      //   1000,
-      //   versionManager.address
-      // );
       await prepaidCardManager.addGasPolicy("transfer", false);
       await prepaidCardManager.addGasPolicy("split", false);
 
@@ -1436,20 +1387,8 @@ contract("PrepaidCardManager", (accounts) => {
       merchantSafe = merchantCreation[0]["merchantSafe"];
     });
 
-    beforeEach(async () => {});
-
     after(async () => {
-      // burn all token in depot wallet
-      let balance = await daicpxdToken.balanceOf(depot.address);
-      let data = daicpxdToken.contract.methods.burn(balance).encodeABI();
-
-      let safeTxData = {
-        to: daicpxdToken.address,
-        data,
-      };
-
-      await signAndSendSafeTransaction(safeTxData, issuer, depot, relayer);
-
+      await burnDepotTokens(depot, daicpxdToken, issuer, relayer);
       // burn all token in relayer wallet
       await daicpxdToken.burn(await daicpxdToken.balanceOf(relayer), {
         from: relayer,

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -914,7 +914,39 @@ contract("PrepaidCardManager", (accounts) => {
     });
   });
 
-  describe("split prepaid card", () => {
+  describe.only("split prepaid card", () => {
+    before(async () => {
+      // Setup card manager contract
+      await prepaidCardManager.setup(
+        tokenManager.address,
+        supplierManager.address,
+        exchange.address,
+        gnosisSafeMasterCopy.address,
+        proxyFactory.address,
+        actionDispatcher.address,
+        gasFeeReceiver,
+        0,
+        MINIMUM_AMOUNT,
+        MAXIMUM_AMOUNT,
+        [contractSigner],
+        versionManager.address
+      );
+      await prepaidCardManager.addGasPolicy("transfer", false);
+      await prepaidCardManager.addGasPolicy("split", false);
+    });
+
+    beforeEach(async () => {
+      await daicpxdToken.mint(depot.address, walletAmount);
+      let amounts = [1, 2, 5].map((amount) => toTokenUnit(amount));
+      ({ prepaidCards } = await createPrepaidCards(
+        depot,
+        prepaidCardManager,
+        daicpxdToken,
+        issuer,
+        relayer,
+        amounts
+      ));
+    });
     it("can split a card (from 1 prepaid card with 2 tokens to 2 cards with 1 token each)", async () => {
       let amounts = [1, 1].map((amount) => toTokenUnit(amount).toString());
       let safeTx = await splitPrepaidCard(

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -346,11 +346,6 @@ contract("PrepaidCardManager", (accounts) => {
         });
     });
 
-    // Note that these prepaid cards are used in the subsequent tests:
-    //   prepaidCards[0] = 1 daicpxd,
-    //   prepaidCards[1] = 2 daicpxd,
-    //   prepaidCards[2] = 5 daicpxd
-    // TODO refactor our tests to be less stateful
     it("should create multi Prepaid Card (1 daicpxd 2 daicpxd 5 daicpxd) ", async () => {
       let amounts = [1, 2, 5].map((amount) => toTokenUnit(amount));
       let paymentActual;
@@ -1173,8 +1168,6 @@ contract("PrepaidCardManager", (accounts) => {
         from: relayer,
       });
     });
-    // Warning this test is stateful, all the other tests rely on this prepaid
-    // card being transferred to a customer
     it("can transfer a card to a customer", async () => {
       let startingDaiBalance = await getBalance(
         daicpxdToken,
@@ -1197,8 +1190,6 @@ contract("PrepaidCardManager", (accounts) => {
       );
     });
 
-    // These tests are stateful (ugh), so the transfer that happened in the
-    // previous test counts against the transfer that is attempted in this test
     it("can not re-transfer a prepaid card that has already been transferred once", async () => {
       let otherCustomer = accounts[9];
       let startingDaiBalance = await getBalance(
@@ -1538,8 +1529,6 @@ contract("PrepaidCardManager", (accounts) => {
       );
     });
 
-    // These tests are stateful (ugh), so the prepaidCards[2] balance is now 4
-    // daicpxd due to the payment of 1 token made in the previous test
     it("can not send more funds to a merchant than the balance of the prepaid card", async () => {
       let startingPrepaidCardDaicpxdBalance = await getBalance(
         daicpxdToken,

--- a/test/PrepaidCardManager-test.js
+++ b/test/PrepaidCardManager-test.js
@@ -1627,7 +1627,7 @@ contract("PrepaidCardManager", (accounts) => {
 
     // These tests are stateful (ugh), so the prepaidCards[2] balance is now 4
     // daicpxd due to the payment of 1 token made in the previous test
-    it.only("can not send more funds to a merchant than the balance of the prepaid card", async () => {
+    it("can not send more funds to a merchant than the balance of the prepaid card", async () => {
       let startingPrepaidCardDaicpxdBalance = await getBalance(
         daicpxdToken,
         prepaidCard.address

--- a/test/utils/helper.js
+++ b/test/utils/helper.js
@@ -1910,6 +1910,18 @@ exports.getPoolBalanceByRewardProgram = async function (
   return rewardPool.rewardBalance(rewardProgramID, token.address);
 };
 
+exports.burnDepotTokens = async function (depot, token, owner, relayer) {
+  let balance = await token.balanceOf(depot.address);
+  let data = token.contract.methods.burn(balance).encodeABI();
+
+  let safeTxData = {
+    to: token.address,
+    data,
+  };
+
+  await signAndSendSafeTransaction(safeTxData, owner, depot, relayer);
+};
+
 exports.toTokenUnit = toTokenUnit;
 exports.encodeCreateCardsData = encodeCreateCardsData;
 exports.packExecutionData = packExecutionData;

--- a/test/utils/helper.js
+++ b/test/utils/helper.js
@@ -34,7 +34,6 @@ const PayRewardTokensHandler = artifacts.require("PayRewardTokensHandler");
 const VersionManager = artifacts.require("VersionManager");
 
 const { toBN } = require("web3-utils");
-const { TOKEN_DETAIL_DATA } = require("../setup");
 const eventABIs = require("./constant/eventABIs");
 const {
   getParamsFromEvent,


### PR DESCRIPTION
Wanted to make each test isolated using the `only()` primitive. So now, the test would work with `test.only` or `describe.only`. Previously, some test were dependent on previous test in previous describe blocks running. 