### PR TITLE
Rename start/end blocks to validFrom/To for clarity

### DIFF
--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -105,8 +105,8 @@ contract RewardPool is Initializable, Versionable, Ownable {
     (
       address rewardProgramID,
       uint256 paymentCycleNumber,
-      uint256 startBlock,
-      uint256 endBlock,
+      uint256 validFrom,
+      uint256 validTo,
       ,
       ,
 
@@ -114,7 +114,7 @@ contract RewardPool is Initializable, Versionable, Ownable {
         leaf,
         (address, uint256, uint256, uint256, uint256, address, bytes)
       );
-    if (block.number >= startBlock && block.number < endBlock) {
+    if (block.number >= validFrom && block.number < validTo) {
       bytes32 root = bytes32(payeeRoots[rewardProgramID][paymentCycleNumber]);
       return proof.verify(root, keccak256(leaf));
     } else {
@@ -178,8 +178,8 @@ contract RewardPool is Initializable, Versionable, Ownable {
     (
       address rewardProgramID,
       ,
-      uint256 startBlock,
-      uint256 endBlock,
+      uint256 validFrom,
+      uint256 validTo,
       uint256 tokenType,
       address payee,
       bytes memory transferDetails
@@ -194,10 +194,10 @@ contract RewardPool is Initializable, Versionable, Ownable {
     );
     require(tokenType == 1, "Token type currently unsupported");
     require(
-      block.number >= startBlock,
+      block.number >= validFrom,
       "Can only be claimed on or after the start block"
     );
-    require(block.number < endBlock, "Can only be claimed before end block");
+    require(block.number < validTo, "Can only be claimed before end block");
     require(valid(leaf, proof), "Proof is invalid");
     require(claimed(leaf) == false, "Reward has already been claimed");
 

--- a/test/RewardPool-test.js
+++ b/test/RewardPool-test.js
@@ -137,8 +137,8 @@ contract("RewardPool", function (accounts) {
       payments = [
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: rewardProgramID,
           payee: accounts[11],
           token: cardcpxdToken.address,
@@ -147,8 +147,8 @@ contract("RewardPool", function (accounts) {
         },
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: rewardProgramID,
           payee: accounts[12],
           token: cardcpxdToken.address,
@@ -157,8 +157,8 @@ contract("RewardPool", function (accounts) {
         },
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: rewardProgramID,
           payee: accounts[13],
           token: cardcpxdToken.address,
@@ -167,8 +167,8 @@ contract("RewardPool", function (accounts) {
         },
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: rewardProgramID,
           payee: accounts[14],
           token: cardcpxdToken.address,
@@ -177,8 +177,8 @@ contract("RewardPool", function (accounts) {
         },
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: rewardProgramID,
           payee: accounts[15],
           token: cardcpxdToken.address,
@@ -187,8 +187,8 @@ contract("RewardPool", function (accounts) {
         },
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: rewardProgramID,
           payee: accounts[18],
           token: cardcpxdToken.address,
@@ -199,8 +199,8 @@ contract("RewardPool", function (accounts) {
       otherPayments = [
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: otherRewardProgramID,
           payee: accounts[16],
           token: cardcpxdToken.address,
@@ -209,8 +209,8 @@ contract("RewardPool", function (accounts) {
         },
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: otherRewardProgramID,
           payee: accounts[17],
           token: cardcpxdToken.address,
@@ -219,8 +219,8 @@ contract("RewardPool", function (accounts) {
         },
         {
           paymentCycleNumber: 1,
-          startBlock: currentBlockNumber,
-          endBlock: currentBlockNumber + 10000,
+          validFrom: currentBlockNumber,
+          validTo: currentBlockNumber + 10000,
           rewardProgramID: rewardProgramID,
           payee: accounts[18],
           token: cardcpxdToken.address,
@@ -1102,8 +1102,8 @@ contract("RewardPool", function (accounts) {
         payments = [
           {
             paymentCycleNumber: 1,
-            startBlock: currentBlockNumber,
-            endBlock: currentBlockNumber + 10000,
+            validFrom: currentBlockNumber,
+            validTo: currentBlockNumber + 10000,
             rewardProgramID: rewardProgramID,
             payee: accounts[1],
             tokenType: 0, // Token type of 0 means that this is not a token
@@ -1111,8 +1111,8 @@ contract("RewardPool", function (accounts) {
           },
           {
             paymentCycleNumber: 1,
-            startBlock: currentBlockNumber,
-            endBlock: currentBlockNumber + 10000,
+            validFrom: currentBlockNumber,
+            validTo: currentBlockNumber + 10000,
             rewardProgramID: rewardProgramID,
             payee: accounts[2],
             token: cardcpxdToken.address,
@@ -1121,8 +1121,8 @@ contract("RewardPool", function (accounts) {
           },
           {
             paymentCycleNumber: 1,
-            startBlock: currentBlockNumber + 1000,
-            endBlock: currentBlockNumber + 10000,
+            validFrom: currentBlockNumber + 1000,
+            validTo: currentBlockNumber + 10000,
             rewardProgramID: rewardProgramID,
             payee: accounts[1],
             tokenType: 0, // Token type of 0 means that this is not a token
@@ -1130,8 +1130,8 @@ contract("RewardPool", function (accounts) {
           },
           {
             paymentCycleNumber: 1,
-            startBlock: currentBlockNumber - 1,
-            endBlock: currentBlockNumber - 1,
+            validFrom: currentBlockNumber - 1,
+            validTo: currentBlockNumber - 1,
             rewardProgramID: rewardProgramID,
             payee: accounts[1],
             tokenType: 0, // Token type of 0 means that this is not a token
@@ -1284,8 +1284,8 @@ contract("RewardPool", function (accounts) {
         payments = [
           {
             paymentCycleNumber: 1,
-            startBlock: currentBlockNumber,
-            endBlock: currentBlockNumber + 10000,
+            validFrom: currentBlockNumber,
+            validTo: currentBlockNumber + 10000,
             rewardProgramID: rewardProgramID,
             payee: payee,
             tokenType: 1,
@@ -1294,8 +1294,8 @@ contract("RewardPool", function (accounts) {
           },
           {
             paymentCycleNumber: 1,
-            startBlock: currentBlockNumber,
-            endBlock: currentBlockNumber + 10000,
+            validFrom: currentBlockNumber,
+            validTo: currentBlockNumber + 10000,
             rewardProgramID: rewardProgramID,
             payee: payee,
             tokenType: 1,

--- a/test/utils/payment-tree.js
+++ b/test/utils/payment-tree.js
@@ -39,8 +39,8 @@ class PaymentTree extends MerkleTree {
       [
         node["rewardProgramID"],
         node["paymentCycleNumber"],
-        node["startBlock"],
-        node["endBlock"],
+        node["validFrom"],
+        node["validTo"],
         node["tokenType"],
         node["payee"],
         transferData,


### PR DESCRIPTION
After some confusion in another review about what the start & end referred to, these have been renamed to talk about when the claim is _valid_. Does not change any behaviour.