### PR TITLE
Improve reward safe events

### DIFF
--- a/contracts/RewardManager.sol
+++ b/contracts/RewardManager.sol
@@ -22,11 +22,6 @@ contract RewardManager is Ownable, Versionable, Safe {
   event RewardProgramRemoved(address rewardProgramID);
   event RewardProgramAdminUpdated(address rewardProgramID, address newAdmin);
   event RewardProgramLocked(address rewardProgramID);
-  event RewardSafeTransferred(
-    address rewardSafe,
-    address oldOwner,
-    address newOwner
-  );
   event RewardRuleAdded(address rewardProgramID, bytes blob);
   event RewardeeRegistered(
     address rewardProgramID,
@@ -186,8 +181,6 @@ contract RewardManager is Ownable, Versionable, Safe {
     );
     ownedRewardSafes[oldOwner][rewardProgramID] = address(0);
     ownedRewardSafes[newOwner][rewardProgramID] = msg.sender;
-
-    emit RewardSafeTransferred(msg.sender, oldOwner, newOwner);
   }
 
   function getRewardSafeOwner(address payable rewardSafe)

--- a/contracts/RewardSafeDelegateImplementation.sol
+++ b/contracts/RewardSafeDelegateImplementation.sol
@@ -24,11 +24,11 @@ import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 // solhint-disable var-name-mixedcase
 contract RewardSafeDelegateImplementation {
   event RewardSafeWithdrawal(address rewardSafe, address token, uint256 value);
-
-  // > web3.utils.keccak256("withdraw(address,address,address,uint256)").slice(0,10)
-  // > web3.utils.keccak256("withdraw(address,address,address,uint256)").slice(0,10)
-  // '0x0b620b81'
-  // bytes4 public constant WITHDRAW = hex"d9caed12";
+  event RewardSafeTransferred(
+    address rewardSafe,
+    address oldOwner,
+    address newOwner
+  );
 
   function withdraw(
     address __trusted__managerContract,
@@ -64,6 +64,12 @@ contract RewardSafeDelegateImplementation {
 
     _originalSafe().swapOwner(
       __untrusted__prevOwner,
+      __untrusted__oldOwner,
+      __untrusted__newOwner
+    );
+
+    emit RewardSafeTransferred(
+      address(this),
       __untrusted__oldOwner,
       __untrusted__newOwner
     );

--- a/test/RewardManager-test.js
+++ b/test/RewardManager-test.js
@@ -1279,7 +1279,7 @@ contract("RewardManager", (accounts) => {
         await rewardManager.ownedRewardSafes(prepaidCardOwner, rewardProgramID)
       ).to.equal(rewardSafe.address);
 
-      await transferRewardSafe({
+      let { safeTx } = await transferRewardSafe({
         rewardManager,
         rewardSafe,
         oldOwner: prepaidCardOwner,
@@ -1287,6 +1287,20 @@ contract("RewardManager", (accounts) => {
         relayer,
         gasToken: daicpxdToken,
       });
+
+      let params = await getParamsFromEvent(
+        safeTx,
+        eventABIs.REWARD_SAFE_TRANSFER,
+        rewardSafe.address
+      );
+
+      expect(params.length).to.equal(1);
+      expect(params[0]).to.deep.include({
+        rewardSafe: rewardSafe.address,
+        oldOwner: prepaidCardOwner,
+        newOwner: otherPrepaidCardOwner,
+      });
+
       owners = await rewardSafe.getOwners();
       expect(owners.length).to.equal(2);
       expect(owners[1]).to.equal(otherPrepaidCardOwner);

--- a/test/utils/constant/eventABIs.js
+++ b/test/utils/constant/eventABIs.js
@@ -257,6 +257,25 @@ const eventABIs = {
       },
     ],
   },
+  REWARD_SAFE_TRANSFER: {
+    topic: web3EthAbi.encodeEventSignature(
+      "RewardSafeTransferred(address,address,address)"
+    ),
+    abis: [
+      {
+        type: "address",
+        name: "rewardSafe",
+      },
+      {
+        type: "address",
+        name: "oldOwner",
+      },
+      {
+        type: "address",
+        name: "newOwner",
+      },
+    ],
+  },
 };
 
 module.exports = eventABIs;


### PR DESCRIPTION
I noticed that the event emission for rewards safe was inconsistent.

Following some discussion, it's unclear if it's easy to have these events
on the safe itself via the delegate or not at the moment from a subgraph POV

I have moved the other event to the safe for now.

My reasoning:

If it's easy to make the subgraph handle this, I think this might be the better
place for the events to live.

If it's not, then we won't rely on it and can move it later, whereas with
the inconsistent location, we might come to rely on events that we later move

This at least makes it consistent and we can move later if we need to for
technical compromise reasons