### PR TITLE
Add leaf in RewardeeClaim event

### DIFF
--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -24,7 +24,8 @@ contract RewardPool is Initializable, Versionable, Ownable {
     address rewardee,
     address rewardSafe,
     address token,
-    uint256 amount
+    uint256 amount,
+    bytes leaf
   );
   event MerkleRootSubmission(
     bytes32 payeeRoot,
@@ -170,7 +171,8 @@ contract RewardPool is Initializable, Versionable, Ownable {
       rewardSafeOwner,
       msg.sender,
       payableToken,
-      amount
+      amount,
+      leaf
     );
   }
 

--- a/test/RewardManager-test.js
+++ b/test/RewardManager-test.js
@@ -1261,7 +1261,7 @@ contract("RewardManager", (accounts) => {
       );
     });
 
-    it.only("can transfer reward safe", async () => {
+    it("can transfer reward safe", async () => {
       let tx = await registerRewardee(
         prepaidCardManager,
         prepaidCard,
@@ -1305,7 +1305,6 @@ contract("RewardManager", (accounts) => {
         oldOwner: prepaidCardOwner,
         newOwner: otherPrepaidCardOwner,
       });
-      console.log(params[0]);
 
       owners = await rewardSafe.getOwners();
       expect(owners.length).to.equal(2);

--- a/test/RewardManager-test.js
+++ b/test/RewardManager-test.js
@@ -48,6 +48,7 @@ const {
   setupVersionManager,
   withdrawFromRewardSafe,
   sendSafeTransaction,
+  generateRewardProgramID,
 } = require("./utils/helper");
 
 const AbiCoder = require("web3-eth-abi");
@@ -386,7 +387,7 @@ contract("RewardManager", (accounts) => {
   describe("register reward program", () => {
     let prepaidCard, otherPrepaidCard;
     beforeEach(async () => {
-      rewardProgramID = randomHex(20);
+      rewardProgramID = generateRewardProgramID();
       prepaidCard = await createPrepaidCardAndTransfer(
         prepaidCardManager,
         relayer,
@@ -557,7 +558,7 @@ contract("RewardManager", (accounts) => {
   describe("update/configure reward program", () => {
     let prepaidCard, otherPrepaidCard;
     beforeEach(async () => {
-      rewardProgramID = randomHex(20);
+      rewardProgramID = generateRewardProgramID();
       prepaidCard = await createPrepaidCardAndTransfer(
         prepaidCardManager,
         relayer,
@@ -1112,7 +1113,7 @@ contract("RewardManager", (accounts) => {
   describe("rewardee registers for reward program", () => {
     let prepaidCard, otherPrepaidCard;
     beforeEach(async () => {
-      rewardProgramID = randomHex(20);
+      rewardProgramID = generateRewardProgramID();
       prepaidCard = await createPrepaidCardAndTransfer(
         prepaidCardManager,
         relayer,
@@ -1238,7 +1239,7 @@ contract("RewardManager", (accounts) => {
     let prepaidCard, rewardSafe;
 
     beforeEach(async () => {
-      rewardProgramID = randomHex(20);
+      rewardProgramID = generateRewardProgramID();
       prepaidCard = await createPrepaidCardAndTransfer(
         prepaidCardManager,
         relayer,
@@ -1260,7 +1261,7 @@ contract("RewardManager", (accounts) => {
       );
     });
 
-    it("can transfer reward safe", async () => {
+    it.only("can transfer reward safe", async () => {
       let tx = await registerRewardee(
         prepaidCardManager,
         prepaidCard,
@@ -1304,6 +1305,7 @@ contract("RewardManager", (accounts) => {
         oldOwner: prepaidCardOwner,
         newOwner: otherPrepaidCardOwner,
       });
+      console.log(params[0]);
 
       owners = await rewardSafe.getOwners();
       expect(owners.length).to.equal(2);
@@ -1589,7 +1591,7 @@ contract("RewardManager", (accounts) => {
     let prepaidCard, rewardSafe;
 
     beforeEach(async () => {
-      rewardProgramID = randomHex(20);
+      rewardProgramID = generateRewardProgramID();
       prepaidCard = await createPrepaidCardAndTransfer(
         prepaidCardManager,
         relayer,

--- a/test/RewardPool-test.js
+++ b/test/RewardPool-test.js
@@ -518,15 +518,6 @@ contract("RewardPool", function (accounts) {
           rewardPool.address
         );
         expect(params.length).to.equal(1);
-        console.log(params[0]);
-        console.log({
-          rewardProgramID,
-          rewardee: payee,
-          rewardSafe: rewardSafe.address,
-          token: cardcpxdToken.address,
-          amount: paymentAmount.toString(),
-          leaf,
-        });
         expect(params[0]).to.deep.include({
           rewardProgramID,
           rewardee: payee,

--- a/test/utils/constant/eventABIs.js
+++ b/test/utils/constant/eventABIs.js
@@ -217,7 +217,7 @@ const eventABIs = {
   },
   REWARDEE_CLAIM: {
     topic: web3EthAbi.encodeEventSignature(
-      "RewardeeClaim(address,address,address,uint256)"
+      "RewardeeClaim(address,address,address,address,uint256,bytes)"
     ),
     abis: [
       {
@@ -233,8 +233,16 @@ const eventABIs = {
         name: "rewardSafe",
       },
       {
+        type: "address",
+        name: "token",
+      },
+      {
         type: "uint256",
         name: "amount",
+      },
+      {
+        type: "bytes",
+        name: "leaf",
       },
     ],
   },

--- a/test/utils/helper.js
+++ b/test/utils/helper.js
@@ -35,7 +35,7 @@ const UpdateRewardProgramAdminHandler = artifacts.require(
 const PayRewardTokensHandler = artifacts.require("PayRewardTokensHandler");
 const VersionManager = artifacts.require("VersionManager");
 
-const { toBN } = require("web3-utils");
+const { toBN, toChecksumAddress, randomHex } = require("web3-utils");
 const eventABIs = require("./constant/eventABIs");
 const {
   getParamsFromEvent,
@@ -1901,6 +1901,10 @@ exports.burnDepotTokens = async function (depot, token, owner, relayer) {
   };
 
   await signAndSendSafeTransaction(safeTxData, owner, depot, relayer);
+};
+
+exports.generateRewardProgramID = () => {
+  return toChecksumAddress(randomHex(20));
 };
 
 exports.toTokenUnit = toTokenUnit;


### PR DESCRIPTION
- Tally has to use the subgraph to track `RewardeeClaim`s. This is so Tally can update it's dbs such that it knows about `proofs` that are already claimed. 
- The leaf is an id we use to identify each proof in the dbs. We can filter by this id and hence mark the proof as claimed. 