### PR TITLE
Fix reward safe transfer attack

### DIFF
--- a/contracts/RewardManager.sol
+++ b/contracts/RewardManager.sol
@@ -175,6 +175,11 @@ contract RewardManager is Ownable, Versionable, Safe {
   function willTransferRewardSafe(address newOwner) external {
     address oldOwner = getRewardSafeOwner(msg.sender);
     address rewardProgramID = rewardProgramsForRewardSafes[msg.sender];
+    require(false,"why does this not revert the transaction");
+    require(
+      ownedRewardSafes[newOwner][rewardProgramID] == address(0),
+      "Cannot transfer to owner which already has reward safe"
+    );
     require(
       ownedRewardSafes[oldOwner][rewardProgramID] == msg.sender,
       "Only current owner can transfer"

--- a/contracts/RewardManager.sol
+++ b/contracts/RewardManager.sol
@@ -175,7 +175,6 @@ contract RewardManager is Ownable, Versionable, Safe {
   function willTransferRewardSafe(address newOwner) external {
     address oldOwner = getRewardSafeOwner(msg.sender);
     address rewardProgramID = rewardProgramsForRewardSafes[msg.sender];
-    require(false,"why does this not revert the transaction");
     require(
       ownedRewardSafes[newOwner][rewardProgramID] == address(0),
       "Cannot transfer to owner which already has reward safe"

--- a/test/RewardManager-test.js
+++ b/test/RewardManager-test.js
@@ -1372,14 +1372,17 @@ contract("RewardManager", (accounts) => {
         )
       ).to.equal(rewardSafe2.address);
 
-      await transferRewardSafe({
+      let {
+        executionResult: { success },
+      } = await transferRewardSafe({
         rewardManager,
         rewardSafe: rewardSafe2,
         oldOwner: otherPrepaidCardOwner,
         newOwner: prepaidCardOwner,
         relayer,
         gasToken: daicpxdToken,
-      }).should.be.rejectedWith(Error, "safe transaction was reverted");
+      });
+      expect(success).to.equal(false);
     });
 
     it("cannot transfer reward safe with swap owner with EOA-signature only", async () => {

--- a/test/RewardManager-test.js
+++ b/test/RewardManager-test.js
@@ -1321,6 +1321,67 @@ contract("RewardManager", (accounts) => {
       ).to.equal(rewardSafe.address);
     });
 
+    it("cannot transfer reward safe", async () => {
+      let otherPrepaidCard = await createPrepaidCardAndTransfer(
+        prepaidCardManager,
+        relayer,
+        depot,
+        issuer,
+        daicpxdToken,
+        toTokenUnit(10 + 1),
+        otherPrepaidCardOwner
+      );
+      let tx1 = await registerRewardee(
+        prepaidCardManager,
+        prepaidCard,
+        relayer,
+        prepaidCardOwner,
+        undefined,
+        rewardProgramID
+      );
+      let rewardSafeCreation1 = await getParamsFromEvent(
+        tx1,
+        eventABIs.REWARDEE_REGISTERED,
+        rewardManager.address
+      );
+      let rewardSafe1 = await GnosisSafe.at(rewardSafeCreation1[0].rewardSafe);
+
+      expect(
+        await rewardManager.ownedRewardSafes(prepaidCardOwner, rewardProgramID)
+      ).to.equal(rewardSafe1.address);
+
+      let tx2 = await registerRewardee(
+        prepaidCardManager,
+        otherPrepaidCard,
+        relayer,
+        otherPrepaidCardOwner,
+        undefined,
+        rewardProgramID
+      );
+      let rewardSafeCreation2 = await getParamsFromEvent(
+        tx2,
+        eventABIs.REWARDEE_REGISTERED,
+        rewardManager.address
+      );
+      let rewardSafe2 = await GnosisSafe.at(rewardSafeCreation2[0].rewardSafe);
+
+      expect(
+        await rewardManager.ownedRewardSafes(
+          otherPrepaidCardOwner,
+          rewardProgramID
+        )
+      ).to.equal(rewardSafe2.address);
+
+      await transferRewardSafe({
+        rewardManager,
+        rewardSafe: rewardSafe2,
+        oldOwner: otherPrepaidCardOwner,
+        newOwner: prepaidCardOwner,
+        relayer,
+        gasToken: daicpxdToken,
+      }).should.be.rejectedWith(Error, "safe transaction was reverted");
+    });
+
     it("cannot transfer reward safe with swap owner with EOA-signature only", async () => {
       const tx = await registerRewardee(
         prepaidCardManager,

--- a/test/RewardManager-test.js
+++ b/test/RewardManager-test.js
@@ -1321,7 +1321,7 @@ contract("RewardManager", (accounts) => {
       ).to.equal(rewardSafe.address);
     });
 
-    it("cannot transfer reward safe", async () => {
+    it("cannot transfer reward safe to an owner who already owns a reward safe", async () => {
       let otherPrepaidCard = await createPrepaidCardAndTransfer(
         prepaidCardManager,
         relayer,


### PR DESCRIPTION
- Attack Scenario: prepaidCardOwner owns rewardSafe1, otherPrepaidCardOwner owns rewardSafe2. otherPrepaidCardOwner can attack prepaidCardOwner by transferring rewardSafe2 to rewardSafe1.
- **I don't know why. but the require is NOT WORKING in `willTransferRewardSafe`**