### PR TITLE
CS-2856 TOB-CSTK-2 use safemath

### DIFF
--- a/contracts/PrepaidCardManager.sol
+++ b/contracts/PrepaidCardManager.sol
@@ -423,7 +423,7 @@ contract PrepaidCardManager is Ownable, Versionable, Safe {
   {
     uint256 amountInSPEND = Exchange(exchangeAddress).convertToSpend(
       token,
-      amount - gasFee(token)
+      amount.sub(gasFee(token))
     );
     return (minimumFaceValue <= amountInSPEND &&
       amountInSPEND <= maximumFaceValue);


### PR DESCRIPTION
I searched for all usages of "+-*\" in all .sol files, and found no key other cases where I think there can be an issue (remaining uses are in loops with fixed lengths, exponentiation).

The remaining places I can see are

https://github.com/cardstack/card-pay-protocol/blob/audit-3/contracts/Exchange.sol#L117

https://github.com/cardstack/card-pay-protocol/blob/audit-3/contracts/Exchange.sol#L162

which uses uint8 (so the existing safemath lib can't be used). Currently the values I think mean this shouldn't be an issue (as we have known tokens), but we could add extra requires checks around the maths equivalent to the safemath checks, swap to uint256 or create a safemath8 that's the same as the safemath code but for uint8s.