### PR TITLE
Cs 2819 Remove uncessary check from Exchange contract

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -92,7 +92,6 @@ contract Exchange is Ownable, Versionable {
       decimals == exchangeRateDecimals(),
       "unexpected decimals value for token price"
     );
-    require(usdRate > 0, "exchange rate cannot be 0");
     return convertToSpendWithRate(token, amount, usdRate);
   }
 

--- a/contracts/dev/MockDIAOracle.sol
+++ b/contracts/dev/MockDIAOracle.sol
@@ -8,6 +8,7 @@ import "../VersionManager.sol";
 
 // This contract is purely for testing and not meant to be deployed
 
+// DIA is a company that is providing a CARD oracle on gnosis chain for us, not a mis-spelling
 contract MockDIAOracle is Ownable, Versionable, IDIAOracle {
   struct PriceData {
     uint128 price;

--- a/contracts/oracles/DIAOracleAdapter.sol
+++ b/contracts/oracles/DIAOracleAdapter.sol
@@ -8,6 +8,8 @@ import "../core/Ownable.sol";
 import "../core/Versionable.sol";
 import "../VersionManager.sol";
 
+// DIA is a company that is providing a CARD oracle on gnosis chain for us, not a mis-spelling
+
 contract DIAOracleAdapter is Ownable, Versionable, IPriceOracle {
   uint8 internal constant DECIMALS = 8;
   address public oracle;

--- a/contracts/oracles/IDIAOracle.sol
+++ b/contracts/oracles/IDIAOracle.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.9;
 pragma abicoder v1;
 
+// DIA is a company that is providing a CARD oracle on gnosis chain for us, not a mis-spelling
 interface IDIAOracle {
   function getValue(string calldata pair)
     external


### PR DESCRIPTION
Audit comment:

> Just as an optimization note on Exchange.convertToSpend – since it's going to call convertToSpendWithRate, this check can probably be removed since it's being checked in the subsequent call https://github.com/cardstack/card-pay-protocol/blob/main/contracts/Exchange.sol#L96