### PR TITLE
Add a reentrancy guard to delegate safe implementation

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -3,6 +3,10 @@ module.exports = {
     // This contract is a mock malicious contract and the tests make sure the code is _not_ run
     "dev/FakeRewardManager.sol",
 
+    // solidity-parser cannot parse this file due to inline assembly
+    // https://github.com/protofire/solhint/issues/328
+    "core/ReentrancyGuard.sol",
+
     // Migration contracts not run in coverage tests
     "migration/EnumerableSetUpgradeUtil.sol",
     "migration/MerchantManagerUpgrader.sol",

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,3 +1,7 @@
 # solidity-parser is not happy about some of the inline assembly in
-# this file even though it compiles and works fine
+# these files even though they compile and work fine
+
+# https://github.com/protofire/solhint/issues/328
+
 ./contracts/migration/EnumerableSetUpgradeUtil.sol
+./contracts/core/ReentrancyGuard.sol

--- a/contracts/RewardSafeDelegateImplementation.sol
+++ b/contracts/RewardSafeDelegateImplementation.sol
@@ -31,12 +31,38 @@ contract RewardSafeDelegateImplementation {
     address newOwner
   );
 
+  // Because this is a delegate implementation, the storage of this contract is the safe storage.
+  // For that reason, we have to do assembly hax to store the reentrancy flag and can't just use
+  // ReentrancyGuardUpgradeable
+
+  // bytes32(uint256(keccak256("safe.delegate.reentrancy_flag")) - 1)
+  bytes32 internal constant REENTRANCY_GUARD_SLOT =
+    0x7712fbd67a2d5bda218f5373b681e9e155932a5fa44c9a20ed14fbb50f32636f;
+
+  modifier nonReentrant() {
+    bool _entered;
+    assembly {
+      _entered := sload(REENTRANCY_GUARD_SLOT)
+    }
+
+    require(!_entered, "reentrant call");
+
+    assembly {
+      sstore(REENTRANCY_GUARD_SLOT, true)
+    }
+    _;
+
+    assembly {
+      sstore(REENTRANCY_GUARD_SLOT, false)
+    }
+  }
+
   function withdraw(
     address __trusted__managerContract,
     address __untrusted__token,
     address __untrusted__to,
     uint256 __untrusted__value
-  ) external {
+  ) nonReentrant external {
     require(
       RewardManager(__trusted__managerContract).isValidToken(
         __untrusted__token

--- a/contracts/core/ReentrancyGuard.sol
+++ b/contracts/core/ReentrancyGuard.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.8.9;
+pragma abicoder v1;
+
+contract ReentrancyGuard {
+  // So this can be used in safe delegate implementations, where the storage of this contract is the safe storage,
+  // we have to do assembly hax to store the reentrancy flag and can't just use
+  // ReentrancyGuardUpgradeable from OZ because it expects a storage slot for its state that
+  // will clobber safe storage
+
+  // bytes32(uint256(keccak256("safe.delegate.reentrancy_flag")) - 1)
+  bytes32 internal constant REENTRANCY_GUARD_SLOT =
+    0x7712fbd67a2d5bda218f5373b681e9e155932a5fa44c9a20ed14fbb50f32636f;
+
+  modifier nonReentrant() {
+    bool _entered;
+
+    assembly {
+      _entered := sload(
+        REENTRANCY_GUARD_SLOT
+      )
+    }
+
+    require(!_entered, "reentrant call");
+
+      assembly {
+        sstore(REENTRANCY_GUARD_SLOT, true)
+      }
+    _;
+
+      assembly {
+        sstore(REENTRANCY_GUARD_SLOT, false)
+      }
+  }
+}


### PR DESCRIPTION
Fixes CS-2882

Not exploitable due to gnosis signing required and whitelisting of tokens, but defence in depth