### PR TITLE
Improve onTokenTransfer hooks documentation

### DIFF
--- a/contracts/ActionDispatcher.sol
+++ b/contracts/ActionDispatcher.sol
@@ -83,11 +83,20 @@ contract ActionDispatcher is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * This will interrogate and perform the requested action from the prepaid
-   * card using the token amount sent.
-   * @param from - who transfer token (should from prepaid card).
-   * @param amount - number token customer pay for merchant.
-   * @param data - merchant safe and infoDID in encode format.
+   *
+   * Performs the requested action from the prepaid card using the token amount sent
+   * by forwarding it to another contract.
+   *
+   * See ActionDispatcher in README for more information.
+   *
+   * @param from - who transfers tokens (should be from a prepaid card)
+   * @param amount - number of tokens (can be 0 when no tokens are required for the action)
+   * @param data - encoded as (
+   *   uint256 spendAmount
+   *   uint256 requestedRate
+   *   string actionName
+   *   bytes actionData
+   * )
    */
   function onTokenTransfer(
     address payable from,

--- a/contracts/PrepaidCardManager.sol
+++ b/contracts/PrepaidCardManager.sol
@@ -182,10 +182,22 @@ contract PrepaidCardManager is Ownable, Versionable, Safe {
   }
 
   /**
-   * @dev onTokenTransfer(ERC677) - call when token send this contract.
-   * @param from Supplier or Prepaid card address
-   * @param amount number token them transfer.
-   * @param data data encoded
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * When tokens are sent to this contract, this function will create multiple
+   * prepaid cards as gnosis safes.
+   *
+   * See PrepaidCardManager in README for more information.
+   *
+   * @param from supplier or Prepaid card address
+   * @param amount number of tokens sent
+   * @param data encoded as (
+   *  address owner (supplier's address),
+   *  uint256[] issuingTokenAmounts (array of issuing token amounts to fund the creation of the prepaid cards),
+   *  uint256[] spendAmounts (array of spend amounts that represent the desired face value (for reporting only)),
+   *  string customizationDID (DID of prepaid card customization data),
+   *  address marketAddress (prepaid card market address)
+   * )
    */
   function onTokenTransfer(
     address from, // solhint-disable-line no-unused-vars

--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -278,11 +278,26 @@ contract RewardPool is Initializable, Versionable, Ownable {
     }
   }
 
+  /**
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * When tokens are sent to this contract, the amount of tokens is added to the
+   * sender's reward balance for the reward program.
+   *
+   * See RewardPool in README for more information.
+   *
+   * @param from sender of the tokens
+   * @param amount number of tokens sent
+   * @param data encoded as: (
+   *  rewardProgramID,
+   * )
+   */
   function onTokenTransfer(
     address from,
     uint256 amount,
     bytes calldata data
   ) external returns (bool) {
+    // msg.sender is the token contract
     require(
       TokenManager(tokenManager).isValidToken(msg.sender),
       "calling token is unaccepted"

--- a/contracts/action-handlers/AddRewardRuleHandler.sol
+++ b/contracts/action-handlers/AddRewardRuleHandler.sol
@@ -41,9 +41,26 @@ contract AddRewardRuleHandler is Ownable, Versionable {
     return true;
   }
 
+  /**
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * This adds the reward rule to the reward manager.
+   *
+   * See AddRewardRuleHandler in README for more information.
+   *
+   * @param from the token sender (should be the action dispatcher)
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 ???,
+   *  bytes actionData, encoded as: (
+   *    address rewardProgramID,
+   *    bytes blob (hex encoding of rule blob)
+   *    )
+   *  )
+   */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount
+    uint256, // amount (we ignore it because this action doesn't require any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -78,6 +95,7 @@ contract AddRewardRuleHandler is Ownable, Versionable {
       ) == prepaidCardOwner,
       "can only be called by reward program admin"
     );
+
     RewardManager(rewardManagerAddress).addRewardRule(rewardProgramID, blob);
     emit RewardRuleAdded(prepaidCard, rewardProgramID, blob);
     return true;

--- a/contracts/action-handlers/LockRewardProgramHandler.sol
+++ b/contracts/action-handlers/LockRewardProgramHandler.sol
@@ -46,7 +46,7 @@ contract LockRewardProgramHandler is Ownable, Versionable {
    * @param from the token sender (should be the action dispatcher)
    * @param data encoded as: (
    *  address prepaidCard,
-   *  uint256 ???,
+   *  uint256 spendAmount (not used here),
    *  bytes actionData, encoded as: (
    *    address rewardProgramID
    *   )

--- a/contracts/action-handlers/LockRewardProgramHandler.sol
+++ b/contracts/action-handlers/LockRewardProgramHandler.sol
@@ -36,9 +36,25 @@ contract LockRewardProgramHandler is Ownable, Versionable {
     return true;
   }
 
+  /**
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * This toggles the lock status of the reward program.
+   *
+   * See LockRewardProgramHandler in README for more information.
+   *
+   * @param from the token sender (should be the action dispatcher)
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 ???,
+   *  bytes actionData, encoded as: (
+   *    address rewardProgramID
+   *   )
+   *  )
+   */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount
+    uint256, // amount (we ignore it because this action doesn't require any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(

--- a/contracts/action-handlers/PayMerchantHandler.sol
+++ b/contracts/action-handlers/PayMerchantHandler.sol
@@ -55,13 +55,23 @@ contract PayMerchantHandler is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * handle a prepaid card payment to a merchant which includes minting
-   * spend into the merchant's safe, collecting protocol fees, and increases the
-   * merchants unclaimed revenue by the issuing token amount minus fees
+   *
+   * When tokens are sent to this contract, this function handles a prepaid card
+   * payment to a merchant, which includes minting SPEND into the merchant's safe,
+   * collecting protocol fees, and increasing the merchant's unclaimed revenue
+   * by the issuing token amount minus fees.
+   *
+   * See PayMerchantHandler in README for more information.
+   *
    * @param from the token sender (should be the action dispatcher)
    * @param amount the amount of tokens being transferred
-   * @param data the data encoded as (address prepaidCard, uint256 spendAmount, bytes actionData)
-   * where actionData is encoded as (address merchantSafe)
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 spendAmount,
+   *  bytes actionData, encoded as: (
+   *    address merchantSafe
+   *  )
+   * )
    */
   function onTokenTransfer(
     address payable from,

--- a/contracts/action-handlers/PayRewardTokensHandler.sol
+++ b/contracts/action-handlers/PayRewardTokensHandler.sol
@@ -37,6 +37,23 @@ contract PayRewardTokensHandler is Ownable, Versionable {
     return true;
   }
 
+  /**
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * When tokens are sent to this contract, it transfers them to the reward pool address.
+   *
+   * See PayRewardTokensHandler in README for more information.
+   *
+   * @param from the token sender (should be the action dispatcher)
+   * @param amount amount in token
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 ???,
+   *  bytes actionData, encoded as: (
+   *    address rewardProgramID
+   *   )
+   *  )
+   */
   function onTokenTransfer(
     address payable from,
     uint256 amount,

--- a/contracts/action-handlers/PayRewardTokensHandler.sol
+++ b/contracts/action-handlers/PayRewardTokensHandler.sol
@@ -48,7 +48,7 @@ contract PayRewardTokensHandler is Ownable, Versionable {
    * @param amount amount in token
    * @param data encoded as: (
    *  address prepaidCard,
-   *  uint256 ???,
+   *  uint256 spendAmount (not used here),
    *  bytes actionData, encoded as: (
    *    address rewardProgramID
    *   )

--- a/contracts/action-handlers/RegisterMerchantHandler.sol
+++ b/contracts/action-handlers/RegisterMerchantHandler.sol
@@ -48,11 +48,22 @@ contract RegisterMerchantHandler is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * handle a merchant registration
+   *
+   * When tokens are sent to this contract, it transfers the merchant registration fee
+   * to the merchant fee receiver, and refunds the amount in case it exceeds the fee.
+   * Then it registers the merchant by creating a new merchant safe.
+   *
+   * See RegisterMerchantHandler in README for more information.
+   *
    * @param from the token sender (should be the action dispatcher)
    * @param amount the amount of tokens being transferred
-   * @param data the data encoded as (address prepaidCard, uint256 spendAmount, bytes actionData)
-   * where actionData is encoded as (address infoDID)
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 spendAmount,
+   *  bytes actionData, encoded as: (
+   *    string infoDID
+   *  )
+   * )
    */
   function onTokenTransfer(
     address payable from,

--- a/contracts/action-handlers/RegisterRewardProgramHandler.sol
+++ b/contracts/action-handlers/RegisterRewardProgramHandler.sol
@@ -52,7 +52,7 @@ contract RegisterRewardProgramHandler is Ownable, Versionable {
    * @param amount the amount of tokens being transferred
    * @param data encoded as: (
    *  address prepaidCard,
-   *  uint256 ?,
+   *  uint256 spendAmount (not used here),
    *  bytes actionData, encoded as: (
    *    address admin,
    *    address rewardProgramID

--- a/contracts/action-handlers/RegisterRewardProgramHandler.sol
+++ b/contracts/action-handlers/RegisterRewardProgramHandler.sol
@@ -39,6 +39,26 @@ contract RegisterRewardProgramHandler is Ownable, Versionable {
     return true;
   }
 
+  /**
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * When tokens are sent to this contract, it transfers the reward program registration fee
+   * to the reward fee receiver, and refunds the amount in case it exceeds the fee.
+   * Then it registers the reward program by adding it to the reward manager.
+   *
+   * See RegisterRewardProgramHandler in README for more information.
+   *
+   * @param from the token sender (should be the action dispatcher)
+   * @param amount the amount of tokens being transferred
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 ?,
+   *  bytes actionData, encoded as: (
+   *    address admin,
+   *    address rewardProgramID
+   *  )
+   * )
+   */
   function onTokenTransfer(
     address payable from,
     uint256 amount,

--- a/contracts/action-handlers/RegisterRewardeeHandler.sol
+++ b/contracts/action-handlers/RegisterRewardeeHandler.sol
@@ -36,9 +36,25 @@ contract RegisterRewardeeHandler is Ownable, Versionable {
     return true;
   }
 
+  /**
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * This registers the prepaid card owner as a rewardee for the reward program.
+   *
+   * See RegisterRewardeeHandler in README for more information.
+   *
+   * @param from the token sender (should be the action dispatcher)
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 ???,
+   *  bytes actionData, encoded as: (
+   *    address rewardProgramID
+   *   )
+   *  )
+   */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount
+    uint256, // amount (we ignore it because this action doesn't require any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(

--- a/contracts/action-handlers/RegisterRewardeeHandler.sol
+++ b/contracts/action-handlers/RegisterRewardeeHandler.sol
@@ -46,7 +46,7 @@ contract RegisterRewardeeHandler is Ownable, Versionable {
    * @param from the token sender (should be the action dispatcher)
    * @param data encoded as: (
    *  address prepaidCard,
-   *  uint256 ???,
+   *  uint256 spendAmount (not used here),
    *  bytes actionData, encoded as: (
    *    address rewardProgramID
    *   )

--- a/contracts/action-handlers/RemovePrepaidCardInventoryHandler.sol
+++ b/contracts/action-handlers/RemovePrepaidCardInventoryHandler.sol
@@ -33,14 +33,22 @@ contract RemovePrepaidCardInventoryHandler is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * handle setting prepaid cards in market inventory
+   *
+   * This handles the removal of a prepaid card from the inventory.
+   *
+   * See RemovePrepaidCardInventoryHandler in README for more information.
+   *
    * @param from the token sender (should be the revenue pool)
-   * @param data the data encoded as (address prepaidCard, uint256 spendAmount, bytes actionData)
-   * where actionData is encoded as (address[] prepaidCards, address marketAddress)
+   * @param data encoded as:
+   *  address prepaidCard,
+   *  uint256 spendAmount,
+   *  bytes actionData, encoded as:
+   *    address[] prepaidCards,
+   *    address marketAddress
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount
+    uint256, // amount (we ignore it because this action doesn't require any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(

--- a/contracts/action-handlers/SetPrepaidCardAskHandler.sol
+++ b/contracts/action-handlers/SetPrepaidCardAskHandler.sol
@@ -33,14 +33,25 @@ contract SetPrepaidCardAskHandler is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * handle setting prepaid cards in market inventory
+   *
+   * This handles setting the ask price for a SKU for the prepaid card.
+   *
+   * See SetPrepaidCardAskHandler in README for more information.
+   *
    * @param from the token sender (should be the revenue pool)
-   * @param data the data encoded as (address prepaidCard, uint256 spendAmount, bytes actionData)
-   * where actionData is encoded as (bytes32 sku, uint256 askPrice, address marketAddress)
+   * @param data encoded as: (
+   *  address prepaidCard,
+   *  uint256 spendAmount,
+   *  bytes actionData, encoded as: (
+   *    bytes32 sku,
+   *    uint256 askPrice,
+   *    address marketAddress
+   *  )
+   * )
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount
+    uint256, // amount (we ignore it because this action doesn't require any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(

--- a/contracts/action-handlers/SetPrepaidCardInventoryHandler.sol
+++ b/contracts/action-handlers/SetPrepaidCardInventoryHandler.sol
@@ -33,14 +33,25 @@ contract SetPrepaidCardInventoryHandler is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * handle setting prepaid cards in market inventory
+   *
+   * This adds the prepaid card safe to the inventory in the PrepaidCardMarket.
+   *
+   * See SetPrepaidCardInventoryHandler in README for more information.
+   *
    * @param from the token sender (should be the revenue pool)
-   * @param data the data encoded as (address prepaidCard, uint256 spendAmount, bytes actionData)
-   * where actionData is encoded as (address prepaidCard, address marketAddress, bytes previousOwnerSignature)
+   * @param data encoded as (
+   *  address prepaidCard,
+   *  uint256 spendAmount,
+   *  bytes actionData, encoded as (
+   *    address prepaidCardForInventory,
+   *    address marketAddress,
+   *    bytes previousOwnerSignature
+   *  )
+   * )
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount
+    uint256, // amount (we ignore it because this action doesn't need any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(

--- a/contracts/action-handlers/SplitPrepaidCardHandler.sol
+++ b/contracts/action-handlers/SplitPrepaidCardHandler.sol
@@ -46,11 +46,24 @@ contract SplitPrepaidCardHandler is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * handle using a prepaid card to create more prepaid cards
+   *
+   * This will receive a payment from a prepaid card, and split it to create more
+   * prepaid cards.
+   *
+   * See SplitPrepaidCardHandler in README for more information.
+   *
    * @param from the token sender (should be the revenue pool)
    * @param amount the amount of tokens being transferred
-   * @param data the data encoded as (address prepaidCard, uint256 spendAmount, bytes actionData)
-   * where actionData is encoded as (uint256[] issuingTokenAmounts, uint256[] spendAmounts, string customizatoinDID, address marketAddress)
+   * @param data encoded as (
+   *  address prepaidCard,
+   *  uint256 spendAmount,
+   *  bytes actionData, encoded as (
+   *    uint256[] issuingTokenAmounts,
+   *    uint256[] spendAmounts,
+   *    string customizationDID,
+   *    address marketAddress
+   *  )
+   * )
    */
   function onTokenTransfer(
     address payable from,

--- a/contracts/action-handlers/TransferPrepaidCardHandler.sol
+++ b/contracts/action-handlers/TransferPrepaidCardHandler.sol
@@ -31,15 +31,24 @@ contract TransferPrepaidCardHandler is Ownable, Versionable {
 
   /**
    * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
-   * handle transferring a prepaid card
+   *
+   * Handle transferring of the prepaid card (gnosis safe) to the new EOA owner.
+   *
+   * See TransferPrepaidCardHandler in README for more information.
+   *
    * @param from the token sender (should be the revenue pool)
-   * //param amount the amount of tokens being transferred
-   * @param data the data encoded as (address prepaidCard, uint256 spendAmount, bytes actionData)
-   * where actionData is encoded as (address newOwner, bytes previousOwnerSignature)
+   * @param data encoded as (
+   *  address prepaidCard,
+   *  uint256 spendAmount,
+   *  bytes actionData, encoded as (
+   *    address newOwner,
+   *    bytes previousOwnerSignature
+   *  )
+   + )
    */
   function onTokenTransfer(
     address payable from,
-    uint256, /* amount */
+    uint256, // amount (we ignore it because this action doesn't need any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(

--- a/contracts/action-handlers/UpdateRewardProgramAdminHandler.sol
+++ b/contracts/action-handlers/UpdateRewardProgramAdminHandler.sol
@@ -51,7 +51,7 @@ contract UpdateRewardProgramAdminHandler is Ownable, Versionable {
    * @param from the token sender (should be the action dispatcher)
    * @param data, encoded as (
    *  address prepaidCard,
-   *  uint256 ???,
+   *  uint256 spendAmount (not used here),
    *  bytes actionData, encoded as: (
    *    address rewardProgramID,
    *    address newAdmin

--- a/contracts/action-handlers/UpdateRewardProgramAdminHandler.sol
+++ b/contracts/action-handlers/UpdateRewardProgramAdminHandler.sol
@@ -41,9 +41,26 @@ contract UpdateRewardProgramAdminHandler is Ownable, Versionable {
     return true;
   }
 
+  /**
+   * @dev onTokenTransfer(ERC677) - this is the ERC677 token transfer callback.
+   *
+   * This sets a new admin for the reward program.
+   *
+   * See UpdateRewardProgramAdminHandler in README for more information.
+   *
+   * @param from the token sender (should be the action dispatcher)
+   * @param data, encoded as (
+   *  address prepaidCard,
+   *  uint256 ???,
+   *  bytes actionData, encoded as: (
+   *    address rewardProgramID,
+   *    address newAdmin
+   *    )
+   *  )
+   */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount
+    uint256, // amount (we ignore it because this action doesn't need any tokens)
     bytes calldata data
   ) external returns (bool) {
     require(


### PR DESCRIPTION
Ticket: CS-3350

This PR aims improve the documentation on how we use the ERC677 `onTokenTransfer` callback in our contracts. It explains the params and offers a short description about its intent and params, and points to the spot in the readme where one can get more details on the handlers. 

~~TODO: checking with @tintinthong to see how to explain the ignored reward related empty param and if we can remove it~~