### PR TITLE
Require 0 token amount where tokens are not needed

### DIFF
--- a/contracts/action-handlers/AddRewardRuleHandler.sol
+++ b/contracts/action-handlers/AddRewardRuleHandler.sol
@@ -60,7 +60,7 @@ contract AddRewardRuleHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't require any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -71,6 +71,8 @@ contract AddRewardRuleHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
+
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,
       (address, uint256, bytes)

--- a/contracts/action-handlers/LockRewardProgramHandler.sol
+++ b/contracts/action-handlers/LockRewardProgramHandler.sol
@@ -54,7 +54,7 @@ contract LockRewardProgramHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't require any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -65,6 +65,8 @@ contract LockRewardProgramHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
+
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,
       (address, uint256, bytes)

--- a/contracts/action-handlers/RegisterRewardeeHandler.sol
+++ b/contracts/action-handlers/RegisterRewardeeHandler.sol
@@ -54,7 +54,7 @@ contract RegisterRewardeeHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't require any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -65,6 +65,8 @@ contract RegisterRewardeeHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
+
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,
       (address, uint256, bytes)

--- a/contracts/action-handlers/RemovePrepaidCardInventoryHandler.sol
+++ b/contracts/action-handlers/RemovePrepaidCardInventoryHandler.sol
@@ -48,7 +48,7 @@ contract RemovePrepaidCardInventoryHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't require any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -59,6 +59,8 @@ contract RemovePrepaidCardInventoryHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
+
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,
       (address, uint256, bytes)

--- a/contracts/action-handlers/SetPrepaidCardAskHandler.sol
+++ b/contracts/action-handlers/SetPrepaidCardAskHandler.sol
@@ -51,7 +51,7 @@ contract SetPrepaidCardAskHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't require any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -62,6 +62,7 @@ contract SetPrepaidCardAskHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
 
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,

--- a/contracts/action-handlers/SetPrepaidCardInventoryHandler.sol
+++ b/contracts/action-handlers/SetPrepaidCardInventoryHandler.sol
@@ -51,7 +51,7 @@ contract SetPrepaidCardInventoryHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't need any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -62,6 +62,8 @@ contract SetPrepaidCardInventoryHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
+
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,
       (address, uint256, bytes)

--- a/contracts/action-handlers/TransferPrepaidCardHandler.sol
+++ b/contracts/action-handlers/TransferPrepaidCardHandler.sol
@@ -48,7 +48,7 @@ contract TransferPrepaidCardHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't need any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -59,6 +59,8 @@ contract TransferPrepaidCardHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
+
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,
       (address, uint256, bytes)

--- a/contracts/action-handlers/UpdateRewardProgramAdminHandler.sol
+++ b/contracts/action-handlers/UpdateRewardProgramAdminHandler.sol
@@ -60,7 +60,7 @@ contract UpdateRewardProgramAdminHandler is Ownable, Versionable {
    */
   function onTokenTransfer(
     address payable from,
-    uint256, // amount (we ignore it because this action doesn't need any tokens)
+    uint256 amount,
     bytes calldata data
   ) external returns (bool) {
     require(
@@ -71,6 +71,8 @@ contract UpdateRewardProgramAdminHandler is Ownable, Versionable {
       from == actionDispatcher,
       "can only accept tokens from action dispatcher"
     );
+    require(amount == 0, "amount must be 0");
+
     (address payable prepaidCard, , bytes memory actionData) = abi.decode(
       data,
       (address, uint256, bytes)


### PR DESCRIPTION
Prevents somebody from accidentally transferring tokens to contracts where we don't require any tokens. 