### PR TITLE
Fix contract verification using nomic provided verification plugin

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,6 +9,7 @@ import "@openzeppelin/hardhat-upgrades";
 import "hardhat-contract-sizer";
 import "hardhat-watcher";
 import "solidity-coverage";
+import "@nomiclabs/hardhat-etherscan";
 import "./lib/hardhat-error-on-compiler-warnings";
 import "./lib/hardhat-use-local-compiler";
 
@@ -155,6 +156,13 @@ let config = {
       ],
       files: ["./test"],
       verbose: true,
+    },
+  },
+
+  etherscan: {
+    apiKey: {
+      xdai: "This just has to be any non-empty string",
+      sokol: "This just has to be any non-empty string",
     },
   },
 };

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,181 +1,25 @@
-const { merge } = require("sol-merger");
-const { plugins } = require("sol-merger/dist/lib/plugins");
-const retry = require("async-await-retry");
-const { readFileSync } = require("fs");
-const { dirname, join } = require("path");
 const hre = require("hardhat");
-const glob = require("glob");
+const axios = require("axios");
 
-async function verifyImpl(contractName, address) {
-  const {
-    network: { name: network },
-    config: {
-      paths: { artifacts: artifactsPath },
-      solidity: { compilers },
-    },
-  } = hre;
-
-  console.log(
-    `Attempting to verify ${contractName} on ${network} at address ${address}`
-  );
-
+async function isVerifiedBlockscout(address) {
   let apiUrl = {
     sokol: "https://blockscout.com/poa/sokol/api",
     xdai: "https://blockscout.com/poa/xdai/api",
-  }[network];
+  }[hre.network.name];
 
-  let contracts = glob.sync(
-    `${hre.config.paths.sources}/**/${contractName}.sol`
-  );
-  if (contracts.length !== 1) {
-    let msg = `Ambiguous contract ${contractName}`;
-    console.log(msg, contracts);
-    throw new Error(msg);
+  if (!apiUrl) {
+    throw new Error(`Could not find api url for network ${hre.network.name}`);
   }
-  let [sourcePath] = contracts;
-  let relativePath = sourcePath.replace(hre.config.paths.sources + "/", "");
-
-  let artifactPath = `${artifactsPath}/contracts/${relativePath}/${contractName}.dbg.json`;
-
-  let { buildInfo } = JSON.parse(readFileSync(artifactPath));
-
-  let buildInfoPath = join(dirname(artifactPath), buildInfo);
-  let { solcVersion, solcLongVersion: compilerVersion } = JSON.parse(
-    readFileSync(buildInfoPath)
-  );
-
-  let {
-    settings: {
-      evmVersion,
-      optimizer: { enabled: optimizationUsed, runs: optimizerRuns },
-    },
-  } = compilers.find((c) => c.version === solcVersion);
-
-  let config = {
-    address,
-    apiUrl,
-    compilerVersion,
-    contractName,
-    sourcePath,
-    optimizationUsed,
-    optimizerRuns,
-    evmVersion,
-  };
-
-  await verifier(config);
-}
-
-async function verifier({
-  address,
-  apiUrl,
-  compilerVersion,
-  contractName,
-  sourcePath,
-  optimizationUsed,
-  optimizerRuns,
-  evmVersion,
-}) {
-  console.log("Attempting to verify contract at", address, "on blockscout");
-
-  const params = {
-    address,
-    contractName,
-    compiler: `v${compilerVersion.replace(".Emscripten.clang", "")}`,
-    optimizationUsed,
-    runs: optimizerRuns,
-    evmVersion,
-    apiUrl,
-  };
 
   try {
-    await retry(async () => {
-      const verified = await verifyContract(sourcePath, params);
-      if (!verified) {
-        let err = "Failed verification, retrying";
-        console.log(err);
-        throw new Error(err);
-      }
-    });
-  } catch (e) {
-    console.log(`It was not possible to verify ${address} on blockscount`);
-  }
-}
-
-async function isVerifiedBlockscout({ address, apiUrl }) {
-  try {
+    let url = `${apiUrl}?module=contract&action=getsourcecode&address=${address}&ignoreProxy=1`;
     const {
       data: { result },
-    } = await axios.get(
-      `${apiUrl}?module=contract&action=getsourcecode&address=${address}&ignoreProxy=1`
-    );
+    } = await axios.get(url);
     return result && result.length && result[0].SourceCode;
   } catch (e) {
+    console.log(e);
     return false;
   }
 }
-
-async function fetchMergedSource(sourcePath) {
-  console.log(`Flattening source file ${sourcePath}`);
-
-  // If a license is provided, we remove all other SPDX-License-Identifiers
-  let mergedSource = await merge(sourcePath, {
-    removeComments: false,
-    exportPlugins: [plugins.SPDXLicenseRemovePlugin],
-  });
-
-  mergedSource = `// SPDX-License-Identifier: MIT\n\n${mergedSource}`;
-
-  return mergedSource;
-}
-
-async function verifyContract(sourcePath, params) {
-  try {
-    let result;
-    if (await isVerifiedBlockscout(params)) {
-      console.log(`${params.address} is already verified on blockscout`);
-      return true;
-    }
-    result = await sendVerifyRequestBlockscout(sourcePath, params);
-
-    if (result.data.message === REQUEST_STATUS.OK) {
-      console.log(`${params.address} verified on blockscout`);
-      return true;
-    }
-  } catch (e) {
-    return false;
-  }
-  return false;
-}
-
-const sendVerifyRequestBlockscout = async (contractPath, options) => {
-  const contract = await fetchMergedSource(contractPath);
-  const postQueries = {
-    module: "contract",
-    action: "verify",
-    addressHash: options.address,
-    contractSourceCode: contract,
-    name: options.contractName,
-    compilerVersion: options.compiler,
-    optimization: options.optimizationUsed,
-    optimizationRuns: options.runs,
-    constructorArguments: options.constructorArguments,
-    evmVersion: options.evmVersion,
-  };
-
-  return sendRequest(options.apiUrl, postQueries);
-};
-
-const axios = require("axios");
-const querystring = require("querystring");
-
-const REQUEST_STATUS = {
-  OK: "OK",
-};
-
-const sendRequest = (url, queries) => {
-  console.log("Posting to", url);
-
-  return axios.post(url, querystring.stringify(queries));
-};
-
-module.exports = { verifyImpl };
+module.exports = { isVerifiedBlockscout };

--- a/package.json
+++ b/package.json
@@ -142,8 +142,7 @@
     "prettier": "^2.2.1",
     "prettier-plugin-solidity": "^1.0.0-beta.19",
     "semver": "^7.3.5",
-    "sol-merger": "^3.1.0",
-    "solc": "0.8.9",
+    "solc": "0.5.17",
     "solhint": "^3.3.6",
     "solidity-coverage": "^0.7.20",
     "trezor-cli-wallet-provider": "^1.0.6",
@@ -162,6 +161,7 @@
     "yarn": "1.22.17"
   },
   "dependencies": {
+    "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@solidity-parser/parser": "0.14.0",
     "@types/async-retry": "^1.4.3",
     "@types/debug": "^4.1.7",

--- a/scripts/deploy/001_initialize_contracts.js
+++ b/scripts/deploy/001_initialize_contracts.js
@@ -1,7 +1,6 @@
 const glob = require("glob");
 const difference = require("lodash/difference");
 const { writeJSONSync, readJSONSync, existsSync } = require("node-fs-extra");
-const { verifyImpl } = require("../../lib/verify");
 
 const hre = require("hardhat");
 
@@ -259,7 +258,10 @@ async function main() {
     ]);
     for (let impl of unverifiedImpls) {
       if (!skipVerify) {
-        await verifyImpl(contractName, impl);
+        await hre.run("verify:verify", {
+          address: impl,
+          constructorArguments: [],
+        });
       }
       newImpls.push(impl);
       reverify.push({ name: contractName, address: impl });
@@ -278,7 +280,7 @@ Deployed Contracts:`);
 Implementation contract verification commands:`);
     for (let { name, address } of reverify) {
       console.log(
-        `env HARDHAT_NETWORK=${network} CONTRACT=${name}@${address} hardhat run scripts/verify.js`
+        `npx hardhat verify --network ${network} ${address} # ${name}`
       );
     }
   }

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -20,20 +20,22 @@ async function main() {
       "0x" + (await ethers.provider.getStorageAt(proxy, IMPL_SLOT)).slice(26);
 
     console.log("Verifying", contractName, "at", implementationAddress);
-    let alreadyVerified = await isVerifiedBlockscout(implementationAddress);
-    if (alreadyVerified) {
-      console.log("Already verified, skipping!");
-    } else {
-      await retry(
-        async () => {
-          await hardhat.run("verify:verify", {
-            address: implementationAddress,
-            constructorArguments: [],
-          });
-        },
-        { retries: 4, minTimeout: 10000 }
-      );
-    }
+    await retry(
+      async () => {
+        let alreadyVerified = await isVerifiedBlockscout(implementationAddress);
+
+        if (alreadyVerified) {
+          console.log("Already verified, skipping!");
+          return;
+        }
+
+        await hardhat.run("verify:verify", {
+          address: implementationAddress,
+          constructorArguments: [],
+        });
+      },
+      { retries: 4, minTimeout: 10000 }
+    );
   }
 }
 

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,41 +1,38 @@
 const { asyncMain } = require("./deploy/util.js");
-const { verifyImpl } = require("../lib/verify");
+const { isVerifiedBlockscout } = require("../lib/verify");
 const hardhat = require("hardhat");
 const { ethers } = hardhat;
+const retry = require("async-retry");
 
 // bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
 const IMPL_SLOT =
   "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
 
 async function main() {
-  let contractAtAddress = process.env.CONTRACT;
+  console.log("verifying all contracts");
 
-  if (contractAtAddress) {
-    let [contractName, address] = contractAtAddress.split("@");
-    if (!contractName || !address) {
-      console.log(
-        "Please provide CONTRACT environment variable as ContractName@hexaddresss"
+  let addresses = require(`../.openzeppelin/addresses-${hardhat.network.name}`);
+
+  for (let contractLabel of Object.keys(addresses)) {
+    let { proxy, contractName } = addresses[contractLabel];
+
+    let implementationAddress =
+      "0x" + (await ethers.provider.getStorageAt(proxy, IMPL_SLOT)).slice(26);
+
+    console.log("Verifying", contractName, "at", implementationAddress);
+    let alreadyVerified = await isVerifiedBlockscout(implementationAddress);
+    if (alreadyVerified) {
+      console.log("Already verified, skipping!");
+    } else {
+      await retry(
+        async () => {
+          await hardhat.run("verify:verify", {
+            address: implementationAddress,
+            constructorArguments: [],
+          });
+        },
+        { retries: 4, minTimeout: 10000 }
       );
-      process.exit(1);
-    }
-
-    console.log("Verifying", contractName, "at", address);
-    await verifyImpl(contractName, address);
-  } else {
-    console.log(
-      "No CONTRACT environment variable provided, verifying all contracts"
-    );
-
-    let addresses = require(`../.openzeppelin/addresses-${hardhat.network.name}`);
-
-    for (let contractLabel of Object.keys(addresses)) {
-      let { proxy, contractName } = addresses[contractLabel];
-
-      let implementationAddress =
-        "0x" + (await ethers.provider.getStorageAt(proxy, IMPL_SLOT)).slice(26);
-
-      console.log("Verifying", contractName, "at", implementationAddress);
-      await verifyImpl(contractName, implementationAddress);
     }
   }
 }

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -19,6 +19,14 @@ async function main() {
     let implementationAddress =
       "0x" + (await ethers.provider.getStorageAt(proxy, IMPL_SLOT)).slice(26);
 
+    if (
+      implementationAddress === "0x0000000000000000000000000000000000000000"
+    ) {
+      // Currently only RewardSafeDelegateImplementation, but this would apply
+      // for any non upgradeable contract
+      implementationAddress = proxy;
+    }
+
     console.log("Verifying", contractName, "at", implementationAddress);
     await retry(
       async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,7 +501,7 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/rlp" "^5.4.0"
 
-"@ethersproject/address@5.6.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.4.0", "@ethersproject/address@^5.6.0":
+"@ethersproject/address@5.6.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.4.0", "@ethersproject/address@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.0.tgz#13c49836d73e7885fc148ad633afad729da25012"
   integrity sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==
@@ -569,17 +569,24 @@
     "@ethersproject/logger" "^5.4.0"
     bn.js "^4.11.9"
 
-"@ethersproject/bytes@5.4.0", "@ethersproject/bytes@^5.0.4":
+"@ethersproject/bytes@5.4.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
   integrity sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==
   dependencies:
     "@ethersproject/logger" "^5.4.0"
 
-"@ethersproject/bytes@5.6.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.4.0", "@ethersproject/bytes@^5.6.0":
+"@ethersproject/bytes@5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.0.tgz#81652f2a0e04533575befadce555213c11d8aa20"
   integrity sha512-3hJPlYemb9V4VLfJF5BfN0+55vltPZSHU3QKUyP9M3Y2TcajbiRrz65UG+xVHOzBereB1b9mn7r12o177xgN7w==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/bytes@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
+  integrity sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
@@ -1178,6 +1185,19 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.2.tgz#c472abcba0c5185aaa4ad4070146e95213c68511"
   integrity sha512-6quxWe8wwS4X5v3Au8q1jOvXYEPkS1Fh+cME5u6AwNdnI4uERvPlVjlgRWzpnb+Rrt1l/cEqiNRH9GlsBMSDQg==
+
+"@nomiclabs/hardhat-etherscan@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.0.3.tgz#ca54a03351f3de41f9f5240e37bea9d64fa24e64"
+  integrity sha512-OfNtUKc/ZwzivmZnnpwWREfaYncXteKHskn3yDnz+fPBZ6wfM4GR+d5RwjREzYFWE+o5iR9ruXhWw/8fejWM9g==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^5.0.2"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    semver "^6.3.0"
+    undici "^4.14.1"
 
 "@nomiclabs/hardhat-truffle5@^2.0.5":
   version "2.0.5"
@@ -2120,7 +2140,7 @@ ansi-mark@^1.0.0:
     strip-ansi "^4.0.0"
     super-split "^1.1.0"
 
-ansi-regex@^2.0.0, ansi-regex@^2.1.1:
+ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
@@ -2164,7 +2184,7 @@ antlr4@4.7.1:
   resolved "https://registry.yarnpkg.com/antlr4/-/antlr4-4.7.1.tgz#69984014f096e9e775f53dd9744bf994d8959773"
   integrity sha512-haHyTW7Y9joE5MVs37P2lNYfU2RWBLfcRDD8OWldcdZm5TiCE91B5Xl1oWSwiDUSd4rlExpt2pu1fksYQjRBYQ==
 
-antlr4ts@^0.5.0-alpha.3, antlr4ts@^0.5.0-alpha.4:
+antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"
   resolved "https://registry.yarnpkg.com/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz#71702865a87478ed0b40c0709f422cf14d51652a"
   integrity sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==
@@ -2989,7 +3009,7 @@ bignumber.js@7.2.1, bignumber.js@^7.2.1:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
   integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
 
-bignumber.js@^9.0.0:
+bignumber.js@^9.0.0, bignumber.js@^9.0.1:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
   integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
@@ -3417,6 +3437,14 @@ caseless@^0.12.0, caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+cbor@^5.0.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.2.0.tgz#4cca67783ccd6de7b50ab4ed62636712f287a67c"
+  integrity sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==
+  dependencies:
+    bignumber.js "^9.0.1"
+    nofilter "^1.0.4"
+
 cbor@^8.0.0:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.0.2.tgz#d0f5088423437efcc160e9304bd0576f45d06abb"
@@ -3623,18 +3651,6 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-cli-color@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-1.4.0.tgz#7d10738f48526824f8fe7da51857cb0f572fe01f"
-  integrity sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==
-  dependencies:
-    ansi-regex "^2.1.1"
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    memoizee "^0.4.14"
-    timers-ext "^0.1.5"
-
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -3783,16 +3799,6 @@ commander@^2.15.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
-commander@^8.1.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 compare-versions@^3.6.0:
   version "3.6.0"
@@ -4546,15 +4552,6 @@ es-to-primitive@^1.2.1:
     is-symbol "^1.0.2"
 
 es5-ext@^0.10.35, es5-ext@^0.10.50:
-  version "0.10.59"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.59.tgz#71038939730eb6f4f165f1421308fb60be363bc6"
-  integrity sha512-cOgyhW0tIJyQY1Kfw6Kr0viu9ZlUctVchRMZ7R0HiH3dxTSp5zJDLecwxUqPUrGKMsgBI1wd1FL+d9Jxfi4cLw==
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    next-tick "^1.1.0"
-
-es5-ext@^0.10.46, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
   version "0.10.53"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
   integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
@@ -4563,7 +4560,7 @@ es5-ext@^0.10.46, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~
     es6-symbol "~3.1.3"
     next-tick "~1.0.0"
 
-es6-iterator@^2.0.3, es6-iterator@~2.0.3:
+es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
   integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
@@ -4572,23 +4569,13 @@ es6-iterator@^2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-symbol@^3.1.1, es6-symbol@^3.1.3, es6-symbol@~3.1.3:
+es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
   integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
   dependencies:
     d "^1.0.1"
     ext "^1.1.2"
-
-es6-weak-map@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
-  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5506,14 +5493,6 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3, ethjs-util@^0.1.6:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -5985,7 +5964,7 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.0.1, fs-extra@^8.1.0:
+fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -7053,11 +7032,6 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-promise@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
-  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
-
 is-regex@^1.0.4, is-regex@^1.1.4, is-regex@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -7854,13 +7828,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
-  dependencies:
-    es5-ext "~0.10.2"
-
 lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
@@ -7952,20 +7919,6 @@ memdown@~3.0.0:
     inherits "~2.0.1"
     ltgt "~2.2.0"
     safe-buffer "~5.1.1"
-
-memoizee@^0.4.14:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
-  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-weak-map "^2.0.3"
-    event-emitter "^0.3.5"
-    is-promise "^2.2.2"
-    lru-queue "^0.1.0"
-    next-tick "^1.1.0"
-    timers-ext "^0.1.7"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -8391,11 +8344,6 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-tick@1, next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
@@ -8472,6 +8420,11 @@ node-releases@^1.1.76:
   version "1.1.77"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.77.tgz#50b0cfede855dd374e7585bf228ff34e57c1c32e"
   integrity sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==
+
+nofilter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
+  integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
 nofilter@^3.0.3:
   version "3.0.3"
@@ -10098,18 +10051,19 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sol-merger@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/sol-merger/-/sol-merger-3.1.0.tgz#547b282a616d106c0fa8869e0a275fd7db0213d8"
-  integrity sha512-4/JELeFlB8bcyqttRZ7pE/EGpevft9Q7IPjMaKLKMrj1exmdyt+1qSfuSXxueFXRZQxSd21u6DjEedDkOtQ5yQ==
+solc@0.5.17:
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.17.tgz#8a76c50e98d49ca7610cca2fdc78ff3016540c67"
+  integrity sha512-qpX+PGaU0Q3c6lh2vDzMoIbhv6bIrecI4bYsx+xUs01xsGFnY6Nr0L8y/QMyutTnrHN6Lb/Yl672ZVRqxka96w==
   dependencies:
-    antlr4ts "^0.5.0-alpha.3"
-    cli-color "^1.4.0"
-    commander "^4.0.1"
-    debug "^4.1.1"
-    fs-extra "^8.0.1"
-    glob "^7.1.2"
-    strip-json-comments "^3.0.1"
+    command-exists "^1.2.8"
+    commander "3.0.2"
+    fs-extra "^0.30.0"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    require-from-string "^2.0.0"
+    semver "^5.5.0"
+    tmp "0.0.33"
 
 solc@0.7.3:
   version "0.7.3"
@@ -10118,21 +10072,6 @@ solc@0.7.3:
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"
-    follow-redirects "^1.12.1"
-    fs-extra "^0.30.0"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    require-from-string "^2.0.0"
-    semver "^5.5.0"
-    tmp "0.0.33"
-
-solc@0.8.9:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.9.tgz#e57eb1c65c1eea273cc9b2b0d6cca051b878cbf8"
-  integrity sha512-dD8tQgGCrdWQPpbDTbQF048S3JAcpytOax2r5qPgQluKJPCRFT6c/fec0ZkbrRwRSeYT/qiKz0OKBDOinnGeWw==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "^8.1.0"
     follow-redirects "^1.12.1"
     fs-extra "^0.30.0"
     js-sha3 "0.8.0"
@@ -10500,7 +10439,7 @@ strip-json-comments@2.0.1, strip-json-comments@^2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@3.1.1, strip-json-comments@^3.0.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -10696,14 +10635,6 @@ timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
   integrity sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=
-
-timers-ext@^0.1.5, timers-ext@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
-  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
-  dependencies:
-    es5-ext "~0.10.46"
-    next-tick "1"
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
@@ -11049,9 +10980,9 @@ underscore@^1.8.3:
   integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 undici@^4.14.1:
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-4.15.1.tgz#c2c0e75f232178f0e6781f6b46c81ccc15065f6e"
-  integrity sha512-h8LJybhMKD09IyQZoQadNtIR/GmugVhTOVREunJrpV6RStriKBFdSVoFzEzTihwXi/27DIBO+Z0OGF+Mzfi0lA==
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-4.16.0.tgz#469bb87b3b918818d3d7843d91a1d08da357d5ff"
+  integrity sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
So, after trying to reproduce verification on etherscan using output we were trying to verify on blockscout, it turns out the problem was not on blockscouts end after all.

The root cause was the sol-merger package, which somehow manages to produce incorrectly merged solidity files, so we were trying to verify the wrong code.

Fortunately for us, nomiclabs have started supporting blockscout in the `@nomiclabs/hardhat-etherscan` package, so we can just use that, it seems to use standard solc input json so avoids the need for flattening altogether.

Lots of code deleted and all our contracts are now verified on xdai!