### PR TITLE
Ensure withdraw works if safe owners changed

### DIFF
--- a/test/utils/helper.js
+++ b/test/utils/helper.js
@@ -2043,3 +2043,4 @@ exports.transferOwner = transferOwner;
 exports.createPrepaidCards = createPrepaidCards;
 exports.transferRewardSafe = transferRewardSafe;
 exports.withdrawFromRewardSafe = withdrawFromRewardSafe;
+exports.SENTINEL_OWNER = SENTINEL_OWNER;


### PR DESCRIPTION
It was a pain to write the test with the safe transaction to swap owners, but it turns out it works fine without changing the contract