### PR TITLE
Recreate revenue pool as safe (Tank)

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,7 +2,14 @@
   "extends": "solhint:recommended",
   "rules": {
     "max-states-count": "off",
+    "not-rely-on-time": "off",
     "compiler-version": ["error", "^0.8.9"],
+    "func-visibility": [
+      "warn", 
+      {
+        "ignoreConstructors": true
+      }
+    ],
     "reason-string": [
       "warn",
       {

--- a/.solhintignore
+++ b/.solhintignore
@@ -5,3 +5,5 @@
 
 ./contracts/migration/EnumerableSetUpgradeUtil.sol
 ./contracts/core/ReentrancyGuard.sol
+
+./contracts/jar/JarGuard.sol

--- a/contracts/jar/JarGuard.sol
+++ b/contracts/jar/JarGuard.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.9;
+pragma abicoder v1;
+
+import "@gnosis.pm/zodiac/contracts/interfaces/IAvatar.sol";
+import "@gnosis.pm/zodiac/contracts/guard/BaseGuard.sol";
+import "@gnosis.pm/zodiac/contracts/factory/FactoryFriendly.sol";
+import "@gnosis.pm/safe-contracts/contracts/common/StorageAccessible.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
+import "../token/IERC677.sol";
+import "./TankModule.sol";
+
+contract JarGuard is FactoryFriendly, BaseGuard {
+  using SafeMathUpgradeable for uint256;
+
+  event JarGuardSetup(address indexed avatar, address[] modules);
+  event ProtectedModulesSet(address[] protectedModules);
+  event AvatarSet(address avatar);
+
+  // Cannot disable this guard
+  error CannotDisableThisGuard(address guard);
+
+  // Cannot disable protected modules
+  error CannotDisableProtecedModules(address module);
+
+  address public avatar;
+  address[] public protectedModules;
+  address public tankModuleAddress;
+
+  // keccak256("guard_manager.guard.address")
+  bytes32 internal constant GUARD_STORAGE_SLOT =
+    0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+  // 0xa9059cbb - bytes4(keccak256("transfer(address,uint256)"))
+  bytes4 public constant TRANSFER = 0xa9059cbb;
+
+  constructor(
+    address _owner,
+    address _avatar,
+    address[] memory _modules,
+    address _tankModuleAddress
+  ) {
+    bytes memory initializeParams = abi.encode(
+      _owner,
+      _avatar,
+      _modules,
+      _tankModuleAddress
+    );
+    setUp(initializeParams);
+  }
+
+  /// @param initializeParams Parameters of initialization encoded
+  function setUp(bytes memory initializeParams) public override initializer {
+    __Ownable_init();
+    (
+      address _owner,
+      address _avatar,
+      address[] memory _modules,
+      address _tankModuleAddress
+    ) = abi.decode(initializeParams, (address, address, address[], address));
+
+    avatar = _avatar;
+    tankModuleAddress = _tankModuleAddress;
+    setProtectedModules(_modules);
+    transferOwnership(_owner);
+
+    emit JarGuardSetup(_avatar, _modules);
+  }
+
+  function setProtectedModules(address[] memory _modules) public onlyOwner {
+    protectedModules = _modules;
+    emit ProtectedModulesSet(protectedModules);
+  }
+
+  function setAvatar(address _avatar) public onlyOwner {
+    avatar = _avatar;
+    emit AvatarSet(avatar);
+  }
+
+  // solhint-disallow-next-line payable-fallback
+  fallback() external {
+    // We don't revert on fallback to avoid issues in case of a Safe upgrade
+    // E.g. The expected check method might change and then the Safe would be locked.
+  }
+
+  function checkTransaction(
+    address to,
+    uint256,
+    bytes calldata data,
+    Enum.Operation operation,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    // solhint-disallow-next-line no-unused-vars
+    address payable,
+    bytes memory,
+    address
+  ) external view override {
+    require(
+      operation != Enum.Operation.DelegateCall,
+      "Delegate call not allowed to this address"
+    );
+
+    if (bytes4(data[:4]) == TRANSFER) {
+      require(
+        IERC677(to).balanceOf(avatar).sub(
+          TankModule(tankModuleAddress).lockedAmount(to)
+        ) >= getAmount(data),
+        "cannot exceed balance - lockedBalance"
+      );
+    }
+  }
+
+  function checkAfterExecution(bytes32, bool) external view override {
+    if (
+      abi.decode(
+        StorageAccessible(avatar).getStorageAt(uint256(GUARD_STORAGE_SLOT), 2),
+        (address)
+      ) != address(this)
+    ) {
+      revert CannotDisableThisGuard(address(this));
+    }
+    for (uint256 i = 0; i < protectedModules.length; i++) {
+      if (!IAvatar(avatar).isModuleEnabled(protectedModules[i])) {
+        revert CannotDisableProtecedModules(protectedModules[i]);
+      }
+    }
+  }
+
+  function getAmount(bytes calldata data) internal pure returns (uint256) {
+    (, uint256 amount) = abi.decode(data[4:], (address, uint256));
+
+    return amount;
+  }
+}

--- a/contracts/jar/TankModule.sol
+++ b/contracts/jar/TankModule.sol
@@ -1,0 +1,319 @@
+pragma solidity ^0.8.9;
+pragma abicoder v1;
+
+import "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol";
+import "../core/ReentrancyGuard.sol";
+import "../token/IERC677.sol";
+import "../MerchantManager.sol";
+import "../TokenManager.sol";
+
+contract TankModule is Module, ReentrancyGuard {
+  using SafeMathUpgradeable for uint256;
+  using SafeERC20Upgradeable for IERC677;
+
+  event TankModuleSetup(
+    address indexed initiator,
+    address indexed owner,
+    address indexed avatar,
+    address target,
+    address merchantManager,
+    address tokenManager,
+    address feeReceiver,
+    uint256 feePercentage,
+    uint256 lockTime,
+    uint256 lastRefundTime
+  );
+  event FundLocked(
+    uint256 indexed queueNonce,
+    address indexed token,
+    address sender,
+    uint256 amount,
+    uint256 startLockTime
+  );
+  event FundReleased(
+    uint256 indexed queueNonce,
+    address indexed token,
+    uint256 amountProceeds
+  );
+  event FeeCollected(
+    uint256 indexed queueNonce,
+    address indexed token,
+    uint256 fee
+  );
+  event FundRefunded(
+    uint256 indexed queueNonce,
+    address indexed token,
+    address sender,
+    uint256 amount
+  );
+
+  struct LockedFund {
+    address sender;
+    address token;
+    uint256 amount;
+    uint256 startLockTime;
+    bool isRefunded;
+  }
+
+  struct RefundableAmount {
+    //Mapping from token address to amount
+    mapping(address => uint256) amount;
+  }
+
+  // 0xa9059cbb - bytes4(keccak256("transfer(address,uint256)"))
+  bytes4 public constant TRANSFER = 0xa9059cbb;
+  uint256 public constant FEE_DECIMALS = 8;
+
+  address public merchantManagerAddress;
+  address public tokenManagerAddress;
+
+  address public feeReceiver;
+  uint256 public feePercentage; // decimals 8
+
+  uint256 public lockTime;
+  uint256 public lastRefundTime;
+
+  uint256 public queueNonce;
+  uint256 public txNonce;
+  // Mapping of queue nonce to locked fund
+  mapping(uint256 => LockedFund) public lockedFund;
+  // Mapping of token to locked amount
+  mapping(address => uint256) public lockedAmount;
+  // Mapping of sender address to refundable amount
+  mapping(address => RefundableAmount) private refundableAmount;
+
+  constructor(
+    address _owner,
+    address _avatar,
+    address _target,
+    address _merchantManagerAddress,
+    address _tokenManagerAddress,
+    address _feeReceiver,
+    uint256 _feePercentage,
+    uint256 _lockTime,
+    uint256 _lastRefundTime
+  ) {
+    bytes memory initParams = abi.encode(
+      _owner,
+      _avatar,
+      _target,
+      _merchantManagerAddress,
+      _tokenManagerAddress,
+      _feeReceiver,
+      _feePercentage,
+      _lockTime,
+      _lastRefundTime
+    );
+    setUp(initParams);
+  }
+
+  function setUp(bytes memory initParams) public override initializer {
+    (
+      address _owner,
+      address _avatar,
+      address _target,
+      address _merchantManagerAddress,
+      address _tokenManagerAddress,
+      address _feeReceiver,
+      uint256 _feePercentage,
+      uint256 _lockTime,
+      uint256 _lastRefundTime
+    ) = abi.decode(
+        initParams,
+        (
+          address,
+          address,
+          address,
+          address,
+          address,
+          address,
+          uint256,
+          uint256,
+          uint256
+        )
+      );
+    __Ownable_init();
+    require(_avatar != address(0), "avatar can not be zero address");
+    require(_target != address(0), "target can not be zero address");
+    require(
+      _merchantManagerAddress != address(0),
+      "merchant manager can not be zero address"
+    );
+    require(
+      _tokenManagerAddress != address(0),
+      "token manager can not be zero address"
+    );
+
+    avatar = _avatar;
+    target = _target;
+    merchantManagerAddress = _merchantManagerAddress;
+    tokenManagerAddress = _tokenManagerAddress;
+    feeReceiver = _feeReceiver;
+    feePercentage = _feePercentage;
+    lockTime = _lockTime;
+    lastRefundTime = _lastRefundTime;
+
+    transferOwnership(_owner);
+
+    emit TankModuleSetup(
+      msg.sender,
+      _owner,
+      _avatar,
+      _target,
+      _merchantManagerAddress,
+      _tokenManagerAddress,
+      _feeReceiver,
+      _feePercentage,
+      _lockTime,
+      _lastRefundTime
+    );
+  }
+
+  function onTokenTransfer(
+    address payable from,
+    uint256 amount,
+    bytes calldata
+  ) external nonReentrant returns (bool) {
+    require(
+      TokenManager(tokenManagerAddress).isValidToken(msg.sender),
+      "calling token is unaccepted"
+    );
+    require(amount > 0, "amount must be greater than 0");
+    require(
+      !MerchantManager(merchantManagerAddress).isMerchantSafeDisabled(avatar),
+      "merchant safe is disabled"
+    );
+
+    IERC677 erc677Token = IERC677(msg.sender);
+    require(
+      erc677Token.balanceOf(address(this)) >= amount,
+      "amount to transfer is greater than balance"
+    );
+
+    lockedFund[queueNonce].sender = from;
+    lockedFund[queueNonce].token = msg.sender;
+    lockedFund[queueNonce].amount = amount;
+    lockedFund[queueNonce].startLockTime = block.timestamp;
+
+    lockedAmount[msg.sender] = lockedAmount[msg.sender].add(amount);
+    refundableAmount[from].amount[msg.sender] = refundableAmount[from]
+      .amount[msg.sender]
+      .add(amount);
+
+    bool result = erc677Token.transfer(avatar, amount);
+    if (!result) return false;
+
+    emit FundLocked(
+      queueNonce,
+      msg.sender,
+      from,
+      amount,
+      lockedFund[queueNonce].startLockTime
+    );
+    queueNonce++;
+    return true;
+  }
+
+  function releaseFund() public {
+    require(queueNonce > txNonce, "no fund was locked");
+
+    LockedFund memory _lockedFund = lockedFund[txNonce];
+    require(
+      block.timestamp.sub(_lockedFund.startLockTime) >= lockTime,
+      "fund still in locking period"
+    );
+    require(!_lockedFund.isRefunded, "fund has been refunded");
+
+    lockedAmount[_lockedFund.token] = lockedAmount[_lockedFund.token].sub(
+      _lockedFund.amount
+    );
+    refundableAmount[_lockedFund.sender].amount[
+      _lockedFund.token
+    ] = refundableAmount[_lockedFund.sender].amount[_lockedFund.token].sub(
+      _lockedFund.amount
+    );
+
+    uint256 ten = 10;
+    uint256 fee = feePercentage > 0
+      ? (_lockedFund.amount * feePercentage) / (ten**FEE_DECIMALS)
+      : 0;
+    uint256 amountProceeds = _lockedFund.amount - fee;
+    bytes memory feeData = abi.encodeWithSelector(TRANSFER, feeReceiver, fee);
+    require(
+      exec(_lockedFund.token, 0, feeData, Enum.Operation.Call),
+      "module transaction fee failed"
+    );
+
+    emit FundReleased(txNonce, _lockedFund.token, amountProceeds);
+    emit FeeCollected(txNonce, _lockedFund.token, fee);
+  }
+
+  function claimBackFund(uint256 _queueNonce) public {
+    LockedFund memory _lockedFund = lockedFund[_queueNonce];
+    require(
+      block.timestamp.sub(_lockedFund.startLockTime) < lockTime,
+      "fund not in locking period"
+    );
+    require(!_lockedFund.isRefunded, "fund has been refunded");
+
+    lockedAmount[_lockedFund.token] = lockedAmount[_lockedFund.token].sub(
+      _lockedFund.amount
+    );
+    refundableAmount[_lockedFund.sender].amount[
+      _lockedFund.token
+    ] = refundableAmount[_lockedFund.sender].amount[_lockedFund.token].sub(
+      _lockedFund.amount
+    );
+    lockedFund[_queueNonce].isRefunded = true;
+
+    bytes memory data = abi.encodeWithSelector(
+      TRANSFER,
+      _lockedFund.sender,
+      _lockedFund.amount
+    );
+    require(
+      exec(_lockedFund.token, 0, data, Enum.Operation.Call),
+      "error on module refund transaction"
+    );
+    emit FundRefunded(
+      _queueNonce,
+      _lockedFund.token,
+      _lockedFund.sender,
+      _lockedFund.amount
+    );
+  }
+
+  function skipRefundedFund() public {
+    while (lockedFund[txNonce].isRefunded) {
+      txNonce++;
+    }
+  }
+
+  function getRefundableAmount(address sender, address token)
+    public
+    view
+    returns (uint256)
+  {
+    return refundableAmount[sender].amount[token];
+  }
+
+  function setMerchantManagerAddress(address _merchantManagerAddress)
+    public
+    onlyOwner
+  {
+    merchantManagerAddress = _merchantManagerAddress;
+  }
+
+  function setTokenManagerAddress(address _tokenManagerAddress)
+    public
+    onlyOwner
+  {
+    tokenManagerAddress = _tokenManagerAddress;
+  }
+
+  function setLockTime(uint256 _lockTime) public onlyOwner {
+    lockTime = _lockTime;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "yarn": "1.22.17"
   },
   "dependencies": {
+    "@gnosis.pm/zodiac": "^1.0.11",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@solidity-parser/parser": "0.14.0",
     "@types/async-retry": "^1.4.3",

--- a/test/TankModule-test.js
+++ b/test/TankModule-test.js
@@ -1,0 +1,239 @@
+const { assert } = require("./setup");
+const { artifacts, contract, network } = require("hardhat");
+const { toBN } = require("web3-utils");
+const { constants } = require("ethers");
+const { signAndSendSafeTransaction } = require("./utils/helper");
+
+const GnosisSafeProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol");
+const GnosisSafe = artifacts.require("GnosisSafe.sol");
+const MerchantManager = artifacts.require("MerchantManager.sol");
+const TokenManager = artifacts.require("TokenManager.sol");
+const TankModule = artifacts.require("TankModule.sol");
+const JarGuard = artifacts.require("JarGuard.sol");
+const ERC677Token = artifacts.require("ERC677Token.sol");
+
+contract("TankModule", (accounts) => {
+  let gnosisSafeProxyFactory,
+    jar,
+    merchantManager,
+    tokenManager,
+    tankModule,
+    jarGuard,
+    erc677Token;
+  let owner, feeReceiver;
+
+  before(async () => {
+    owner = accounts[0];
+    feeReceiver = accounts[1];
+
+    erc677Token = await ERC677Token.new();
+    await erc677Token.initialize("TEST", "TEST", 10, owner);
+
+    merchantManager = await MerchantManager.new();
+    await merchantManager.initialize(owner);
+
+    tokenManager = await TokenManager.new();
+    await tokenManager.initialize(owner);
+    await tokenManager.addPayableToken(erc677Token.address);
+
+    gnosisSafeProxyFactory = await GnosisSafeProxyFactory.new();
+    const gnosisSingleton = await GnosisSafe.new();
+    const gnosisSetupCall = gnosisSingleton.contract.methods
+      .setup(
+        [owner],
+        1,
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
+        constants.AddressZero,
+        0,
+        constants.AddressZero
+      )
+      .encodeABI();
+    const resultGnosisFactory = await gnosisSafeProxyFactory.createProxy(
+      gnosisSingleton.address,
+      gnosisSetupCall
+    );
+    jar = await GnosisSafe.at(resultGnosisFactory.logs[0].args.proxy);
+
+    tankModule = await TankModule.new(
+      jar.address,
+      jar.address,
+      jar.address,
+      merchantManager.address,
+      tokenManager.address,
+      feeReceiver,
+      toBN("10000000"),
+      toBN("600"),
+      toBN("1")
+    );
+
+    jarGuard = await JarGuard.new(
+      jar.address,
+      jar.address,
+      [tankModule.address],
+      tankModule.address
+    );
+
+    const enableModule = jar.contract.methods.enableModule(tankModule.address);
+    const enableModuleSafeTx = {
+      to: jar.address,
+      data: enableModule.encodeABI(),
+      txGasEstimate: await enableModule.estimateGas({ from: jar.address }),
+      gasPrice: 0,
+      txGasToken: constants.AddressZero,
+      refundReceiver: constants.AddressZero,
+    };
+    await signAndSendSafeTransaction(enableModuleSafeTx, owner, jar, owner);
+
+    const setGuard = jar.contract.methods.setGuard(jarGuard.address);
+    const setGuardSafeTx = {
+      to: jar.address,
+      data: setGuard.encodeABI(),
+      txGasEstimate: await setGuard.estimateGas({ from: jar.address }),
+      gasPrice: 0,
+      txGasToken: constants.AddressZero,
+      refundReceiver: constants.AddressZero,
+    };
+    await signAndSendSafeTransaction(setGuardSafeTx, owner, jar, owner);
+  });
+
+  describe("transfer fund flow", () => {
+    let queueNonce;
+
+    it("should increase queue nonce and locked fund", async () => {
+      const sender = accounts[3];
+
+      const tokenMinted = toBN("20000000000");
+      await erc677Token.mint(sender, tokenMinted);
+      const initBalance = await erc677Token.balanceOf(sender);
+      assert.equal(initBalance.toString(), tokenMinted.toString());
+
+      const initialQueueNonce = await tankModule.queueNonce();
+      const initialSafeBalance = await erc677Token.balanceOf(jar.address);
+
+      const transferAmount = toBN("10000000000");
+      await erc677Token.transferAndCall(
+        tankModule.address,
+        transferAmount,
+        constants.AddressZero,
+        { from: sender }
+      );
+
+      queueNonce = await tankModule.queueNonce();
+      const finalSafeBalance = await erc677Token.balanceOf(jar.address);
+      assert.equal(
+        queueNonce.toString(),
+        initialQueueNonce.add(toBN(1)).toString()
+      );
+      assert.equal(
+        finalSafeBalance.toString(),
+        initialSafeBalance.add(transferAmount).toString()
+      );
+      assert.equal(
+        (await tankModule.lockedAmount(erc677Token.address)).toString(),
+        transferAmount.toString()
+      );
+    });
+
+    it("should failed transfer fund that hasn't been released yet", async () => {
+      const transferAmount = toBN("10000000000");
+      const transferToken = erc677Token.contract.methods.transfer(
+        accounts[3],
+        transferAmount
+      );
+      const transferSafeTx = {
+        to: erc677Token.address,
+        data: transferToken.encodeABI(),
+        txGasEstimate: await transferToken.estimateGas({ from: jar.address }),
+        gasPrice: 0,
+        txGasToken: constants.AddressZero,
+        refundReceiver: constants.AddressZero,
+      };
+
+      await signAndSendSafeTransaction(
+        transferSafeTx,
+        owner,
+        jar,
+        owner
+      ).should.be.rejectedWith(Error, "cannot exceed balance - lockedBalance");
+    });
+
+    it("should failed release fund that still in locking period", async () => {
+      await tankModule
+        .releaseFund()
+        .should.be.rejectedWith(Error, "fund still in locking period");
+    });
+
+    it("should success release fund after locking period", async () => {
+      await network.provider.send("evm_increaseTime", [3600]);
+      await tankModule.releaseFund().should.not.be.rejected;
+
+      const finalSafeBalance = await erc677Token.balanceOf(jar.address);
+      const finalFeeReceiverBalance = await erc677Token.balanceOf(feeReceiver);
+
+      assert.equal(finalSafeBalance.toString(), "9000000000");
+      assert.equal(finalFeeReceiverBalance.toString(), "1000000000"); // 10% of released fund
+    });
+
+    it("should success transfer fund that has been released", async () => {
+      const transferAmount = toBN("9000000000");
+      const transferToken = erc677Token.contract.methods.transfer(
+        accounts[3],
+        transferAmount
+      );
+      const transferSafeTx = {
+        to: erc677Token.address,
+        data: transferToken.encodeABI(),
+        txGasEstimate: await transferToken.estimateGas({ from: jar.address }),
+        gasPrice: 0,
+        txGasToken: constants.AddressZero,
+        refundReceiver: constants.AddressZero,
+      };
+
+      await signAndSendSafeTransaction(transferSafeTx, owner, jar, owner).should
+        .not.be.rejected;
+
+      const finalSafeBalance = await erc677Token.balanceOf(jar.address);
+      assert.equal(finalSafeBalance.toString(), "0");
+    });
+
+    it("should failed to claimback fund that has been released", async () => {
+      await tankModule
+        .claimBackFund(queueNonce)
+        .should.be.rejectedWith(Error, "fund not in locking period");
+    });
+  });
+
+  describe("cancel fund flow", () => {
+    let queueNonce, sender;
+
+    before(async () => {
+      sender = accounts[3];
+
+      const tokenMinted = toBN("20000000000");
+      await erc677Token.mint(sender, tokenMinted);
+
+      queueNonce = await tankModule.queueNonce();
+      const transferAmount = toBN("10000000000");
+      await erc677Token.transferAndCall(
+        tankModule.address,
+        transferAmount,
+        constants.AddressZero,
+        { from: sender }
+      );
+    });
+
+    it("can cancel or claim back fund that still in locking period", async () => {
+      const initialSenderBalance = await erc677Token.balanceOf(sender);
+      await tankModule.claimBackFund(queueNonce).should.not.be.rejected;
+
+      const lockedFund = await tankModule.lockedFund(queueNonce);
+      assert.equal(
+        (await erc677Token.balanceOf(sender)).toString(),
+        initialSenderBalance.add(lockedFund.amount).toString()
+      );
+      assert.isTrue(lockedFund.isRefunded);
+    });
+  });
+});


### PR DESCRIPTION
This is the result of a spike process to recreate revenue pools as a safe by leveraging the safe module and guard. Users can directly send tokens to the merchant safe (jar) without worrying about losing pool capabilities. The Tank module helps users to record the locking period of tokens they send to merchant safe (jars). Jar Guard will ensure that only tokens that have been released and exceed the locking period merchants can spend from the jar.