### PR TITLE
Forbid registering a supplier twice

### DIFF
--- a/contracts/SupplierManager.sol
+++ b/contracts/SupplierManager.sol
@@ -70,6 +70,7 @@ contract SupplierManager is Ownable, Versionable, Safe {
       msg.sender == bridgeUtils || (owner() == _msgSender()),
       "caller is not BridgeUtils nor owner"
     );
+    require(!isRegistered(supplier), "supplier already registered");
     return _registerSupplier(supplier);
   }
 

--- a/test/BridgeUtils-test.js
+++ b/test/BridgeUtils-test.js
@@ -276,31 +276,18 @@ contract("BridgeUtils", async (accounts) => {
     );
   });
 
-  it("Returns the original depot if you register twice", async () => {
-    let newSupplier = accounts[6];
-    let txFirstRegister = await bridgeUtils.registerSupplier(newSupplier, {
+  it("does not allow registering twice", async () => {
+    let newSupplier = accounts[2];
+    await bridgeUtils.registerSupplier(newSupplier, {
       from: mediatorBridgeMock,
     });
 
-    let eventParamsFirstRegister = utils.getParamsFromEvent(
-      txFirstRegister,
-      eventABIs.SUPPLIER_SAFE_CREATED,
-      supplierManager.address
-    );
-    let depotFirstRegister = eventParamsFirstRegister[0].safe;
-
-    let txSecondRegister = await bridgeUtils.registerSupplier(newSupplier, {
-      from: mediatorBridgeMock,
-    });
-
-    let eventParamsSecondRegister = utils.getParamsFromEvent(
-      txSecondRegister,
-      eventABIs.SUPPLIER_SAFE_CREATED,
-      supplierManager.address
-    );
-    let depotSecondRegister = eventParamsSecondRegister[0].safe;
-
-    expect(depotFirstRegister).to.equal(depotSecondRegister);
     expect(await bridgeUtils.isRegistered(newSupplier)).to.equal(true);
+
+    await bridgeUtils
+      .registerSupplier(newSupplier, {
+        from: mediatorBridgeMock,
+      })
+      .should.be.rejectedWith(Error, "supplier already registered");
   });
 });


### PR DESCRIPTION
The test in commit https://github.com/cardstack/card-pay-protocol/commit/a2a2013c08cd3306c967d597ecbf4830832fdaa9 shows that if you register a supplier twice, a new depot is created and the contract loses track of the original one. I expect this would have bad side effects, while the funds in the original depot would not be lost the supplier manager would start returning a new empty safe.

I may be missing an expected flow though.

I've added an extra guard & test checking it's not able to be called twice. 